### PR TITLE
feat(auth): implement secure auth service

### DIFF
--- a/services/auth-service/alembic.ini
+++ b/services/auth-service/alembic.ini
@@ -1,0 +1,3 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///./app.db

--- a/services/auth-service/alembic/env.py
+++ b/services/auth-service/alembic/env.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "app"))
+
+from app.database import Base  # noqa: E402
+from app import models  # noqa: E402,F401
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/services/auth-service/alembic/versions/0001_initial.py
+++ b/services/auth-service/alembic/versions/0001_initial.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "auth_users",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("email", sa.String(), nullable=False, unique=True),
+        sa.Column("password_hash", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+    op.create_table(
+        "refresh_tokens",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("user_id", sa.String(length=36), nullable=False),
+        sa.Column("token", sa.String(), nullable=False, unique=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["auth_users.id"], ondelete="CASCADE"),
+    )
+    op.create_table(
+        "password_resets",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("user_id", sa.String(length=36), nullable=False),
+        sa.Column("token", sa.String(), nullable=False, unique=True),
+        sa.Column("used", sa.Boolean(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["auth_users.id"], ondelete="CASCADE"),
+    )
+    op.create_table(
+        "audit_log",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("user_id", sa.String(length=36), nullable=True),
+        sa.Column("action", sa.String(), nullable=False),
+        sa.Column("ip_address", sa.String(), nullable=True),
+        sa.Column("user_agent", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("audit_log")
+    op.drop_table("password_resets")
+    op.drop_table("refresh_tokens")
+    op.drop_table("auth_users")

--- a/services/auth-service/app/api.py
+++ b/services/auth-service/app/api.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.orm import Session
+
+from . import audit, models, schemas, security
+from .database import get_db
+from .settings import get_settings
+
+router = APIRouter()
+settings = get_settings()
+
+security_scheme = HTTPBearer(auto_error=False)
+
+
+@router.post("/register", response_model=schemas.UserRead, status_code=status.HTTP_201_CREATED)
+def register(user_in: schemas.UserCreate, db: Session = Depends(get_db)):
+    existing = db.query(models.AuthUser).filter_by(email=user_in.email).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Email already registered")
+    user = models.AuthUser(email=user_in.email, password_hash=security.hash_password(user_in.password))
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    audit.log_event(db, "register", user.id)
+    return user
+
+
+@router.post("/login", response_model=schemas.TokenResponse)
+def login(request: Request, credentials: schemas.LoginRequest, db: Session = Depends(get_db)):
+    if security.is_throttled(credentials.email):
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Too many attempts")
+    user = db.query(models.AuthUser).filter_by(email=credentials.email).first()
+    if not user or not security.verify_password(credentials.password, user.password_hash):
+        security.register_failed_attempt(credentials.email)
+        raise HTTPException(status_code=400, detail="Invalid credentials")
+    security.clear_failed_attempts(credentials.email)
+    access_token = security.create_access_token({"sub": str(user.id)})
+    refresh_token = str(uuid4())
+    rt = models.RefreshToken(
+        user_id=user.id,
+        token=refresh_token,
+        expires_at=datetime.utcnow() + timedelta(days=settings.refresh_token_expires_days),
+    )
+    db.add(rt)
+    db.commit()
+    audit.log_event(
+        db,
+        "login",
+        user.id,
+        request.client.host if request.client else None,
+        request.headers.get("user-agent"),
+    )
+    return schemas.TokenResponse(access_token=access_token, refresh_token=refresh_token)
+
+
+@router.post("/refresh", response_model=schemas.TokenResponse)
+def refresh_token(data: schemas.RefreshRequest, db: Session = Depends(get_db)):
+    token_row = db.query(models.RefreshToken).filter_by(token=data.refresh_token).first()
+    if not token_row or token_row.expires_at < datetime.utcnow():
+        raise HTTPException(status_code=400, detail="Invalid refresh token")
+    access_token = security.create_access_token({"sub": str(token_row.user_id)})
+    return schemas.TokenResponse(access_token=access_token, refresh_token=data.refresh_token)
+
+
+@router.post("/forgot-password")
+def forgot_password(data: schemas.ForgotPasswordRequest, db: Session = Depends(get_db)):
+    user = db.query(models.AuthUser).filter_by(email=data.email).first()
+    if not user:
+        return {"message": "ok"}
+    token = str(uuid4())
+    pr = models.PasswordReset(
+        user_id=user.id,
+        token=token,
+        expires_at=datetime.utcnow() + timedelta(hours=1),
+    )
+    db.add(pr)
+    db.commit()
+    audit.log_event(db, "forgot-password", user.id)
+    return {"message": "ok"}
+
+
+@router.post("/reset-password")
+def reset_password(data: schemas.ResetPasswordRequest, db: Session = Depends(get_db)):
+    pr = db.query(models.PasswordReset).filter_by(token=data.token, used=False).first()
+    if not pr or pr.expires_at < datetime.utcnow():
+        raise HTTPException(status_code=400, detail="Invalid token")
+    user = db.query(models.AuthUser).filter_by(id=pr.user_id).first()
+    if not user:
+        raise HTTPException(status_code=400, detail="Invalid token")
+    user.password_hash = security.hash_password(data.password)
+    pr.used = True
+    db.commit()
+    audit.log_event(db, "reset-password", user.id)
+    return {"message": "ok"}
+
+
+@router.get("/me", response_model=schemas.UserRead)
+def me(
+    credentials: HTTPAuthorizationCredentials = Depends(security_scheme),
+    db: Session = Depends(get_db),
+):
+    if not credentials:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+    try:
+        payload = security.decode_token(credentials.credentials)
+        user_id = payload.get("sub")
+    except Exception as exc:  # pragma: no cover
+        raise HTTPException(status_code=401, detail="Invalid token") from exc
+    user = db.get(models.AuthUser, UUID(str(user_id)))
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user

--- a/services/auth-service/app/audit.py
+++ b/services/auth-service/app/audit.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from .models import AuditLog
+
+
+def log_event(
+    db: Session,
+    action: str,
+    user_id: Optional[UUID] = None,
+    ip: str | None = None,
+    user_agent: str | None = None,
+) -> None:
+    entry = AuditLog(user_id=user_id, action=action, ip_address=ip, user_agent=user_agent)
+    db.add(entry)
+    db.commit()

--- a/services/auth-service/app/database.py
+++ b/services/auth-service/app/database.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
+
+from .settings import get_settings
+
+
+class Base(DeclarativeBase):
+    """Base class for all SQLAlchemy models."""
+
+
+settings = get_settings()
+
+engine = create_engine(
+    str(settings.database_url),
+    connect_args={"check_same_thread": False} if str(settings.database_url).startswith("sqlite") else {},
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/services/auth-service/app/main.py
+++ b/services/auth-service/app/main.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from . import security
+from .api import router as auth_router
+from .database import Base, engine
+
+app = FastAPI()
+
+
+@app.on_event("startup")
+def on_startup() -> None:  # pragma: no cover - database creation side effect
+    Base.metadata.create_all(bind=engine)
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+app.include_router(auth_router, prefix="/auth")
+
+
+@app.get("/.well-known/jwks.json")
+def jwks() -> dict[str, object]:
+    return security.get_jwks()

--- a/services/auth-service/app/models.py
+++ b/services/auth-service/app/models.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+
+from .database import Base
+
+
+class AuthUser(Base):
+    __tablename__ = "auth_users"
+
+    id = Column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    email = Column(String, unique=True, index=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class RefreshToken(Base):
+    __tablename__ = "refresh_tokens"
+
+    id = Column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    user_id = Column(PGUUID(as_uuid=True), ForeignKey("auth_users.id", ondelete="CASCADE"), nullable=False)
+    token = Column(String, unique=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    expires_at = Column(DateTime, nullable=False)
+
+
+class PasswordReset(Base):
+    __tablename__ = "password_resets"
+
+    id = Column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    user_id = Column(PGUUID(as_uuid=True), ForeignKey("auth_users.id", ondelete="CASCADE"), nullable=False)
+    token = Column(String, unique=True, nullable=False)
+    used = Column(Boolean, default=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    expires_at = Column(DateTime, nullable=False)
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_log"
+
+    id = Column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    user_id = Column(PGUUID(as_uuid=True), ForeignKey("auth_users.id"), nullable=True)
+    action = Column(String, nullable=False)
+    ip_address = Column(String, nullable=True)
+    user_agent = Column(String, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/services/auth-service/app/schemas.py
+++ b/services/auth-service/app/schemas.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr
+
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class UserRead(BaseModel):
+    id: UUID
+    email: EmailStr
+
+    class Config:
+        from_attributes = True
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+
+
+class ResetPasswordRequest(BaseModel):
+    token: str
+    password: str

--- a/services/auth-service/app/security.py
+++ b/services/auth-service/app/security.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+import uuid
+
+import jwt
+from jwt.utils import base64url_encode
+from passlib.context import CryptContext
+
+from .settings import get_settings
+
+try:
+    import redis  # type: ignore
+except Exception:  # pragma: no cover
+    redis = None  # type: ignore
+
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+settings = get_settings()
+redis_client = redis.from_url(settings.redis_url) if settings.redis_url and redis else None
+
+LOGIN_ATTEMPTS = 5
+LOGIN_WINDOW_SECONDS = 300
+
+
+def hash_password(password: str) -> str:
+    pepper = settings.password_pepper or ""
+    return pwd_context.hash(password + pepper)
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    pepper = settings.password_pepper or ""
+    return pwd_context.verify(password + pepper, hashed)
+
+
+def create_access_token(data: dict[str, Any], expires_delta: timedelta | None = None) -> str:
+    to_encode = data.copy()
+    expire = datetime.now(timezone.utc) + (
+        expires_delta or timedelta(minutes=settings.access_token_expires_minutes)
+    )
+    to_encode.update({"exp": expire})
+    headers = {"kid": settings.jwt_key_id}
+    return jwt.encode(to_encode, settings.jwt_private_key, algorithm=settings.jwt_algorithm, headers=headers)
+
+
+def decode_token(token: str) -> dict[str, Any]:
+    return jwt.decode(token, settings.jwt_public_key, algorithms=[settings.jwt_algorithm], options={"verify_aud": False})
+
+
+def get_jwk() -> dict[str, Any]:
+    if settings.jwt_algorithm.startswith("RS"):
+        from cryptography.hazmat.primitives import serialization
+
+        public_key = serialization.load_pem_public_key(settings.jwt_public_key.encode())
+        numbers = public_key.public_numbers()
+        n = base64url_encode(numbers.n.to_bytes((numbers.n.bit_length() + 7) // 8, "big")).decode()
+        e = base64url_encode(numbers.e.to_bytes((numbers.e.bit_length() + 7) // 8, "big")).decode()
+        return {
+            "kty": "RSA",
+            "use": "sig",
+            "kid": settings.jwt_key_id,
+            "alg": settings.jwt_algorithm,
+            "n": n,
+            "e": e,
+        }
+    else:
+        from cryptography.hazmat.primitives import serialization
+
+        public_key = serialization.load_pem_public_key(settings.jwt_public_key.encode())
+        raw = public_key.public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        x = base64url_encode(raw).decode()
+        return {
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "use": "sig",
+            "kid": settings.jwt_key_id,
+            "alg": settings.jwt_algorithm,
+            "x": x,
+        }
+
+
+def get_jwks() -> dict[str, Any]:
+    return {"keys": [get_jwk()]}
+
+
+def register_failed_attempt(identifier: str) -> None:
+    if redis_client:
+        key = f"login:{identifier}"
+        count = redis_client.incr(key)
+        if count == 1:
+            redis_client.expire(key, LOGIN_WINDOW_SECONDS)
+
+
+def clear_failed_attempts(identifier: str) -> None:
+    if redis_client:
+        redis_client.delete(f"login:{identifier}")
+
+
+def is_throttled(identifier: str) -> bool:
+    if not redis_client:
+        return False
+    val = redis_client.get(f"login:{identifier}")
+    if not val:
+        return False
+    try:
+        return int(val) >= LOGIN_ATTEMPTS
+    except (TypeError, ValueError):
+        return False

--- a/services/auth-service/app/settings.py
+++ b/services/auth-service/app/settings.py
@@ -9,14 +9,16 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    jwt_secret_key: str = Field(..., alias="JWT_SECRET_KEY")
-    jwt_algorithm: str = Field(..., alias="JWT_ALGORITHM")
     database_url: AnyUrl = Field(..., alias="DATABASE_URL")
-    smtp_host: str = Field(..., alias="SMTP_HOST")
-    smtp_port: int = Field(..., alias="SMTP_PORT")
-    smtp_user: str = Field(..., alias="SMTP_USER")
-    smtp_password: str = Field(..., alias="SMTP_PASSWORD")
-    cors_allow_origins: List[str] = Field(..., alias="CORS_ALLOW_ORIGINS")
+    jwt_private_key: str = Field(..., alias="JWT_PRIVATE_KEY")
+    jwt_public_key: str = Field(..., alias="JWT_PUBLIC_KEY")
+    jwt_algorithm: str = Field("RS256", alias="JWT_ALGORITHM")
+    jwt_key_id: str = Field(..., alias="JWT_KEY_ID")
+    access_token_expires_minutes: int = Field(15, alias="ACCESS_TOKEN_EXPIRES_MINUTES")
+    refresh_token_expires_days: int = Field(7, alias="REFRESH_TOKEN_EXPIRES_DAYS")
+    password_pepper: str | None = Field("", alias="PASSWORD_PEPPER")
+    redis_url: str | None = Field(None, alias="REDIS_URL")
+    cors_allow_origins: List[str] = Field(["*"], alias="CORS_ALLOW_ORIGINS")
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/services/auth-service/tests/conftest.py
+++ b/services/auth-service/tests/conftest.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Generator
+
+import fakeredis
+import pytest
+from fastapi.testclient import TestClient
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+@pytest.fixture(scope="function")
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    priv_pem = private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    pub_pem = private_key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    monkeypatch.setenv("JWT_PRIVATE_KEY", priv_pem.decode())
+    monkeypatch.setenv("JWT_PUBLIC_KEY", pub_pem.decode())
+    monkeypatch.setenv("JWT_ALGORITHM", "RS256")
+    monkeypatch.setenv("JWT_KEY_ID", "test-key")
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRES_MINUTES", "15")
+    monkeypatch.setenv("REFRESH_TOKEN_EXPIRES_DAYS", "7")
+    monkeypatch.setenv("PASSWORD_PEPPER", "")
+    monkeypatch.setenv("CORS_ALLOW_ORIGINS", "[\"*\"]")
+
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    from app.main import app  # noqa: E402
+    from app import security  # noqa: E402
+    from app.database import Base, engine  # noqa: E402
+
+    security.redis_client = fakeredis.FakeRedis()  # type: ignore[assignment]
+    Base.metadata.create_all(bind=engine)
+
+    with TestClient(app) as c:
+        yield c
+

--- a/services/auth-service/tests/test_auth.py
+++ b/services/auth-service/tests/test_auth.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+
+def test_register_login_me_flow(client) -> None:
+    resp = client.post("/auth/register", json={"email": "user@example.com", "password": "secret"})
+    assert resp.status_code == 201
+    user_id = resp.json()["id"]
+
+    resp = client.post("/auth/login", json={"email": "user@example.com", "password": "secret"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "access_token" in data
+    assert "refresh_token" in data
+    access = data["access_token"]
+    refresh = data["refresh_token"]
+
+    resp = client.get("/auth/me", headers={"Authorization": f"Bearer {access}"})
+    assert resp.status_code == 200
+    me = resp.json()
+    assert me["email"] == "user@example.com"
+    assert me["id"] == user_id
+
+    resp = client.post("/auth/refresh", json={"refresh_token": refresh})
+    assert resp.status_code == 200
+    assert resp.json()["access_token"]
+

--- a/services/auth-service/tests/test_healthz.py
+++ b/services/auth-service/tests/test_healthz.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+
+def test_healthz(client) -> None:
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add FastAPI auth service with health check and JWKS endpoint
- implement SQLAlchemy models, Alembic migrations and auth routes
- support JWT, bcrypt hashing with pepper and Redis login throttling

## Testing
- `make lint`
- `make typecheck` *(fails: There are no .py[i] files in directory '.')*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68965efdb7e4832380a362226c6228d2