### PR TITLE
Implement user service with RBAC and initial data seeding

### DIFF
--- a/services/user-service/alembic.ini
+++ b/services/user-service/alembic.ini
@@ -1,0 +1,3 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///./app.db

--- a/services/user-service/alembic/env.py
+++ b/services/user-service/alembic/env.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import sys
+from logging.config import fileConfig
+from pathlib import Path
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "app"))
+
+from app import models  # noqa: E402,F401
+from app.database import Base  # noqa: E402
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/services/user-service/alembic/versions/0001_initial.py
+++ b/services/user-service/alembic/versions/0001_initial.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("email", sa.String(), nullable=False, unique=True),
+        sa.Column("full_name", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+    op.create_table(
+        "roles",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False, unique=True),
+    )
+    op.create_table(
+        "sectors",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False, unique=True),
+    )
+    op.create_table(
+        "user_roles",
+        sa.Column("user_id", sa.String(length=36), nullable=False),
+        sa.Column("role_id", sa.String(length=36), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["role_id"], ["roles.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "role_id"),
+    )
+    op.create_table(
+        "user_sectors",
+        sa.Column("user_id", sa.String(length=36), nullable=False),
+        sa.Column("sector_id", sa.String(length=36), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["sector_id"], ["sectors.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "sector_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_sectors")
+    op.drop_table("user_roles")
+    op.drop_table("sectors")
+    op.drop_table("roles")
+    op.drop_table("users")

--- a/services/user-service/app/api.py
+++ b/services/user-service/app/api.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from . import models, schemas, security
+from .database import get_db
+
+router = APIRouter()
+
+
+@router.get("/users/me", response_model=schemas.UserRead)
+def read_me(
+    payload: dict = Depends(security.get_current_payload),
+    db: Session = Depends(get_db),
+):
+    user_id = payload.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=400, detail="Invalid token")
+    user = db.get(models.User, UUID(str(user_id)))
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@router.get("/users", response_model=list[schemas.UserRead])
+def list_users(
+    page: int = 1,
+    page_size: int = 10,
+    db: Session = Depends(get_db),
+    payload: dict = Depends(security.require_roles(["admin"])),
+):
+    offset = (page - 1) * page_size
+    users = db.query(models.User).offset(offset).limit(page_size).all()
+    return users
+
+
+@router.post("/users", response_model=schemas.UserRead, status_code=201)
+def create_user(
+    user_in: schemas.UserCreate,
+    db: Session = Depends(get_db),
+    payload: dict = Depends(security.require_roles(["admin"])),
+):
+    existing = db.query(models.User).filter_by(email=user_in.email).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Email already registered")
+    user = models.User(email=user_in.email, full_name=user_in.full_name)
+    if user_in.roles:
+        roles = db.query(models.Role).filter(models.Role.name.in_(user_in.roles)).all()
+        user.roles = roles
+    if user_in.sectors:
+        sectors = (
+            db.query(models.Sector)
+            .filter(models.Sector.name.in_(user_in.sectors))
+            .all()
+        )
+        user.sectors = sectors
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@router.patch("/users/{user_id}", response_model=schemas.UserRead)
+def update_user(
+    user_id: UUID,
+    user_in: schemas.UserUpdate,
+    db: Session = Depends(get_db),
+    payload: dict = Depends(security.require_roles(["admin"])),
+):
+    user = db.get(models.User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    if user_in.full_name is not None:
+        user.full_name = user_in.full_name
+    if user_in.roles is not None:
+        roles = db.query(models.Role).filter(models.Role.name.in_(user_in.roles)).all()
+        user.roles = roles
+    if user_in.sectors is not None:
+        sectors = (
+            db.query(models.Sector)
+            .filter(models.Sector.name.in_(user_in.sectors))
+            .all()
+        )
+        user.sectors = sectors
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@router.get("/roles", response_model=list[schemas.RoleRead])
+def list_roles(
+    db: Session = Depends(get_db),
+    payload: dict = Depends(security.require_roles(["admin"])),
+):
+    return db.query(models.Role).all()
+
+
+@router.get("/sectors", response_model=list[schemas.SectorRead])
+def list_sectors(
+    db: Session = Depends(get_db),
+    payload: dict = Depends(security.get_current_payload),
+):
+    return db.query(models.Sector).all()

--- a/services/user-service/app/database.py
+++ b/services/user-service/app/database.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
+
+from .settings import get_settings
+
+
+class Base(DeclarativeBase):
+    """Base class for all SQLAlchemy models."""
+
+
+settings = get_settings()
+
+engine = create_engine(
+    str(settings.database_url),
+    connect_args=(
+        {"check_same_thread": False}
+        if str(settings.database_url).startswith("sqlite")
+        else {}
+    ),
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/services/user-service/app/main.py
+++ b/services/user-service/app/main.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .api import router
+from .database import Base, engine, get_db
+from .seed import seed_initial_data
+
+app = FastAPI()
+
+
+@app.on_event("startup")
+def on_startup() -> None:  # pragma: no cover - database side effects
+    Base.metadata.create_all(bind=engine)
+    # Seed initial data
+    with next(get_db()) as db:
+        seed_initial_data(db)
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+app.include_router(router)

--- a/services/user-service/app/models.py
+++ b/services/user-service/app/models.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .database import Base
+
+
+class UserRole(Base):
+    __tablename__ = "user_roles"
+    user_id = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    role_id = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("roles.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+
+
+class UserSector(Base):
+    __tablename__ = "user_sectors"
+    user_id = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    sector_id = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("sectors.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[PGUUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    email: Mapped[str] = mapped_column(String, unique=True, index=True, nullable=False)
+    full_name: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    roles: Mapped[list["Role"]] = relationship(
+        "Role",
+        secondary="user_roles",
+        back_populates="users",
+    )
+    sectors: Mapped[list["Sector"]] = relationship(
+        "Sector",
+        secondary="user_sectors",
+        back_populates="users",
+    )
+
+
+class Role(Base):
+    __tablename__ = "roles"
+
+    id: Mapped[PGUUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+
+    users: Mapped[list[User]] = relationship(
+        "User", secondary="user_roles", back_populates="roles"
+    )
+
+
+class Sector(Base):
+    __tablename__ = "sectors"
+
+    id: Mapped[PGUUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+
+    users: Mapped[list[User]] = relationship(
+        "User", secondary="user_sectors", back_populates="sectors"
+    )

--- a/services/user-service/app/schemas.py
+++ b/services/user-service/app/schemas.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr
+
+
+class RoleRead(BaseModel):
+    id: UUID
+    name: str
+
+    class Config:
+        from_attributes = True
+
+
+class SectorRead(BaseModel):
+    id: UUID
+    name: str
+
+    class Config:
+        from_attributes = True
+
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    full_name: str | None = None
+    roles: list[str] = []  # role names
+    sectors: list[str] = []  # sector names
+
+
+class UserUpdate(BaseModel):
+    full_name: str | None = None
+    roles: list[str] | None = None
+    sectors: list[str] | None = None
+
+
+class UserRead(BaseModel):
+    id: UUID
+    email: EmailStr
+    full_name: str | None = None
+    roles: list[RoleRead] = []
+    sectors: list[SectorRead] = []
+
+    class Config:
+        from_attributes = True

--- a/services/user-service/app/security.py
+++ b/services/user-service/app/security.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Callable
+
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from .settings import get_settings
+
+settings = get_settings()
+
+security_scheme = HTTPBearer(auto_error=False)
+
+
+def decode_token(token: str) -> dict:
+    try:
+        payload = jwt.decode(
+            token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm]
+        )
+    except jwt.PyJWTError as exc:  # pragma: no cover - invalid tokens
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        ) from exc
+    return payload
+
+
+def get_current_payload(
+    credentials: HTTPAuthorizationCredentials | None = Depends(security_scheme),
+) -> dict:
+    if not credentials:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
+        )
+    return decode_token(credentials.credentials)
+
+
+def require_roles(required: list[str]) -> Callable[[dict], dict]:
+    def dependency(payload: dict = Depends(get_current_payload)) -> dict:
+        roles = payload.get("roles", [])
+        if any(role in roles for role in required):
+            return payload
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions"
+        )
+
+    return dependency

--- a/services/user-service/app/seed.py
+++ b/services/user-service/app/seed.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from . import models
+
+
+def seed_initial_data(db: Session) -> None:
+    # Seed roles
+    if not db.query(models.Role).first():
+        db.add_all([models.Role(name="admin"), models.Role(name="user")])
+        db.commit()
+    # Seed sectors
+    if not db.query(models.Sector).first():
+        gerente = models.Sector(name="Gerente")
+        db.add(gerente)
+        db.commit()
+    # Seed admin user
+    admin = db.query(models.User).filter_by(email="admin@example.com").first()
+    if not admin:
+        admin = models.User(email="admin@example.com", full_name="Admin")
+        admin_role = db.query(models.Role).filter_by(name="admin").first()
+        gerente_sector = db.query(models.Sector).filter_by(name="Gerente").first()
+        if admin_role:
+            admin.roles.append(admin_role)
+        if gerente_sector:
+            admin.sectors.append(gerente_sector)
+        db.add(admin)
+        db.commit()

--- a/services/user-service/tests/conftest.py
+++ b/services/user-service/tests/conftest.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Generator
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(scope="function")
+def client(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Generator[TestClient, None, None]:
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+    monkeypatch.setenv("JWT_ALGORITHM", "HS256")
+    monkeypatch.setenv("SMTP_HOST", "smtp")
+    monkeypatch.setenv("SMTP_PORT", "25")
+    monkeypatch.setenv("SMTP_USER", "user")
+    monkeypatch.setenv("SMTP_PASSWORD", "pass")
+    monkeypatch.setenv("CORS_ALLOW_ORIGINS", '["*"]')
+
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    from app.database import Base, engine  # noqa: E402
+    from app.main import app  # noqa: E402
+
+    Base.metadata.create_all(bind=engine)
+
+    with TestClient(app) as c:
+        yield c
+
+
+def create_token(user_id: str, roles: list[str]) -> str:
+    from app.settings import get_settings
+
+    settings = get_settings()
+    payload = {"sub": user_id, "roles": roles}
+    return jwt.encode(
+        payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm
+    )

--- a/services/user-service/tests/test_healthz.py
+++ b/services/user-service/tests/test_healthz.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+
+def test_healthz(client):
+    res = client.get("/healthz")
+    assert res.status_code == 200
+    assert res.json() == {"status": "ok"}

--- a/services/user-service/tests/test_users.py
+++ b/services/user-service/tests/test_users.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import jwt
+
+
+def create_token(user_id: str, roles: list[str]) -> str:
+    from app.settings import get_settings
+
+    settings = get_settings()
+    payload = {"sub": user_id, "roles": roles}
+    return jwt.encode(
+        payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm
+    )
+
+
+def get_admin_token() -> str:
+    from app import models
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+    admin = db.query(models.User).filter_by(email="admin@example.com").first()
+    token = create_token(str(admin.id), ["admin"])
+    db.close()
+    return token
+
+
+def test_users_me_and_sectors_seed(client):
+    token = get_admin_token()
+    res = client.get("/users/me", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 200
+    data = res.json()
+    assert data["email"] == "admin@example.com"
+    assert any(s["name"] == "Gerente" for s in data["sectors"])
+
+
+def test_get_users_requires_admin(client):
+    from app import models
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+    admin = db.query(models.User).filter_by(email="admin@example.com").first()
+    db.close()
+    token = create_token(str(admin.id), ["user"])  # not admin
+    res = client.get("/users", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 403
+
+
+def test_create_and_list_users_with_pagination(client):
+    admin_token = get_admin_token()
+    for i in range(3):
+        res = client.post(
+            "/users",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={
+                "email": f"user{i}@example.com",
+                "full_name": f"User {i}",
+                "roles": ["user"],
+                "sectors": [],
+            },
+        )
+        assert res.status_code == 201
+    res1 = client.get(
+        "/users",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        params={"page": 1, "page_size": 2},
+    )
+    res2 = client.get(
+        "/users",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        params={"page": 2, "page_size": 2},
+    )
+    assert res1.status_code == 200 and res2.status_code == 200
+    assert len(res1.json()) == 2
+    assert len(res2.json()) >= 1
+    assert res1.json()[0]["id"] != res2.json()[0]["id"]
+
+
+def test_patch_user_and_roles_sectors(client):
+    admin_token = get_admin_token()
+    res = client.post(
+        "/users",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "email": "patch@example.com",
+            "full_name": "Patch User",
+            "roles": [],
+            "sectors": [],
+        },
+    )
+    assert res.status_code == 201
+    user_id = res.json()["id"]
+    res_patch = client.patch(
+        f"/users/{user_id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"full_name": "Updated", "roles": ["user"], "sectors": ["Gerente"]},
+    )
+    assert res_patch.status_code == 200
+    data = res_patch.json()
+    assert data["full_name"] == "Updated"
+    assert any(r["name"] == "user" for r in data["roles"])
+    assert any(s["name"] == "Gerente" for s in data["sectors"])
+
+
+def test_roles_and_sectors_endpoints(client):
+    admin_token = get_admin_token()
+    res_roles = client.get("/roles", headers={"Authorization": f"Bearer {admin_token}"})
+    assert res_roles.status_code == 200
+    assert any(r["name"] == "admin" for r in res_roles.json())
+    res_sectors = client.get(
+        "/sectors", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert res_sectors.status_code == 200
+    assert any(s["name"] == "Gerente" for s in res_sectors.json())
+
+
+def test_pydantic_validation(client):
+    admin_token = get_admin_token()
+    res = client.post(
+        "/users",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"email": "not-an-email", "full_name": "x"},
+    )
+    assert res.status_code == 422


### PR DESCRIPTION
## Summary
- add FastAPI-based user service with health check
- implement RBAC-aware endpoints for managing users, roles and sectors
- seed default roles, sectors and admin user

## Testing
- `pytest services/user-service/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68966212fba08323bb17925e167eddaf