### PR TITLE
Configure Traefik routers and middleware

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -49,10 +49,15 @@ services:
       - traefik
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.auth.rule=Host(`auth.localhost`)"
-      - "traefik.http.routers.auth.entrypoints=web"
       - "traefik.http.services.auth.loadbalancer.server.port=8000"
-      - "traefik.http.routers.auth.middlewares=secure-headers@file,rate-limit@file"
+      - "traefik.http.routers.auth.rule=Host(`api.tasks.localhost`) && PathPrefix(`/auth`)"
+      - "traefik.http.routers.auth.entrypoints=web"
+      - "traefik.http.routers.auth.middlewares=secure-headers@file,rate-limit@file,cors@file,compress@file"
+      - "traefik.http.routers.auth-login.rule=Host(`api.tasks.localhost`) && Path(`/auth/login`)"
+      - "traefik.http.routers.auth-login.entrypoints=web"
+      - "traefik.http.routers.auth-login.priority=100"
+      - "traefik.http.routers.auth-login.middlewares=secure-headers@file,rate-limit@file,login-rate-limit@file,cors@file,compress@file"
+      - "traefik.http.routers.auth-login.service=auth"
 
   user-service:
     build: ./services/user-service
@@ -61,10 +66,10 @@ services:
       - traefik
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.user.rule=Host(`user.localhost`)"
-      - "traefik.http.routers.user.entrypoints=web"
       - "traefik.http.services.user.loadbalancer.server.port=8000"
-      - "traefik.http.routers.user.middlewares=secure-headers@file,rate-limit@file"
+      - "traefik.http.routers.user.rule=Host(`api.tasks.localhost`) && PathPrefix(`/users`)"
+      - "traefik.http.routers.user.entrypoints=web"
+      - "traefik.http.routers.user.middlewares=secure-headers@file,rate-limit@file,cors@file,compress@file"
 
   web:
     build: ./web
@@ -73,10 +78,10 @@ services:
       - traefik
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.web.rule=Host(`web.localhost`)"
-      - "traefik.http.routers.web.entrypoints=web"
       - "traefik.http.services.web.loadbalancer.server.port=3000"
-      - "traefik.http.routers.web.middlewares=secure-headers@file,rate-limit@file"
+      - "traefik.http.routers.web.rule=Host(`app.tasks.localhost`)"
+      - "traefik.http.routers.web.entrypoints=web"
+      - "traefik.http.routers.web.middlewares=secure-headers@file,rate-limit@file,compress@file"
 
 networks:
   traefik:

--- a/docker/traefik/dynamic.yml
+++ b/docker/traefik/dynamic.yml
@@ -15,4 +15,18 @@ http:
     rate-limit:
       rateLimit:
         average: 100
-        burst: 50
+        burst: 100
+        period: 1m
+    login-rate-limit:
+      rateLimit:
+        average: 5
+        burst: 5
+        period: 1m
+    cors:
+      headers:
+        accessControlAllowOriginList:
+          - "https://app.tasks.localhost"
+        accessControlAllowCredentials: true
+        addVaryHeader: true
+    compress:
+      compress: {}


### PR DESCRIPTION
## Summary
- route `/auth` and `/users` under api.tasks.localhost to auth-service and user-service respectively
- add CORS, compression, and rate limiting (global 100/min; /auth/login 5/min)
- expose app at app.tasks.localhost with security headers

## Testing
- `pre-commit run --files compose.yml docker/traefik/dynamic.yml`
- `mypy .` *(no files checked)*
- `pytest` *(missing jwt and fakeredis modules)*

------
https://chatgpt.com/codex/tasks/task_e_689746a0d5bc832391841302c2c0da65