### PR TITLE
feat: add observability and debug docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ Para executar a aplicação web localmente em um ambiente macOS:
 
 O aplicativo estará disponível em [http://localhost:3000](http://localhost:3000).
 
+## Debug
+
+Algumas ferramentas úteis para depuração em ambiente local:
+
+- **Mailhog**: servidor SMTP falso para inspecionar e-mails enviados.
+  Após subir os containers com `docker compose up`, acesse a interface web em
+  [http://localhost:8025](http://localhost:8025). Utilize o host `mailhog` e
+  porta `1025` nas configurações de envio de e-mail das aplicações.
+- **pgcli**: cliente interativo para o Postgres. Conecte-se ao banco de dados
+  com `pgcli postgresql://app:app@localhost:5432/app` para executar consultas e
+  inspeções de dados.
+
 ## Convenções de commit
 
 Utilizamos [Conventional Commits](https://www.conventionalcommits.org/) para padronizar as mensagens de commit.

--- a/compose.yml
+++ b/compose.yml
@@ -47,9 +47,17 @@ services:
     networks:
       - internal
       - traefik
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     labels:
       - "traefik.enable=true"
       - "traefik.http.services.auth.loadbalancer.server.port=8000"
+      - "traefik.http.services.auth.loadbalancer.healthcheck.path=/healthz"
+      - "traefik.http.services.auth.loadbalancer.healthcheck.interval=10s"
+      - "traefik.http.services.auth.loadbalancer.serversTransport=default@file"
       - "traefik.http.routers.auth.rule=Host(`api.tasks.localhost`) && PathPrefix(`/auth`)"
       - "traefik.http.routers.auth.entrypoints=web"
       - "traefik.http.routers.auth.middlewares=secure-headers@file,rate-limit@file,cors@file,compress@file"
@@ -64,9 +72,17 @@ services:
     networks:
       - internal
       - traefik
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     labels:
       - "traefik.enable=true"
       - "traefik.http.services.user.loadbalancer.server.port=8000"
+      - "traefik.http.services.user.loadbalancer.healthcheck.path=/healthz"
+      - "traefik.http.services.user.loadbalancer.healthcheck.interval=10s"
+      - "traefik.http.services.user.loadbalancer.serversTransport=default@file"
       - "traefik.http.routers.user.rule=Host(`api.tasks.localhost`) && PathPrefix(`/users`)"
       - "traefik.http.routers.user.entrypoints=web"
       - "traefik.http.routers.user.middlewares=secure-headers@file,rate-limit@file,cors@file,compress@file"

--- a/docker/traefik/dynamic.yml
+++ b/docker/traefik/dynamic.yml
@@ -30,3 +30,8 @@ http:
         addVaryHeader: true
     compress:
       compress: {}
+  serversTransports:
+    default:
+      forwardingTimeouts:
+        dialTimeout: 5s
+        responseHeaderTimeout: 10s

--- a/services/auth-service/app/main.py
+++ b/services/auth-service/app/main.py
@@ -1,12 +1,78 @@
 from __future__ import annotations
 
-from fastapi import FastAPI
+import json
+import logging
+import uuid
+from contextvars import ContextVar
+
+from fastapi import FastAPI, Request
+from prometheus_client import make_asgi_app
 
 from . import security
 from .api import router as auth_router
 from .database import Base, engine
 
+request_id_ctx = ContextVar("request_id", default="")
+
+
+class RequestIdFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_ctx.get()
+        return True
+
+
+class JsonFormatter(logging.Formatter):
+    def format(
+        self, record: logging.LogRecord
+    ) -> str:  # pragma: no cover - simple formatting
+        log: dict[str, object] = {
+            "level": record.levelname,
+            "message": record.getMessage(),
+        }
+        if getattr(record, "request_id", ""):
+            log["request_id"] = record.request_id
+        for attr in ("method", "path", "status_code"):
+            if hasattr(record, attr):
+                log[attr] = getattr(record, attr)
+        return json.dumps(log)
+
+
+def setup_logging() -> None:
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    handler.addFilter(RequestIdFilter())
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(logging.INFO)
+
+
+setup_logging()
+
 app = FastAPI()
+metrics_app = make_asgi_app()
+app.mount("/metrics", metrics_app)
+
+
+@app.middleware("http")
+async def add_request_id(request: Request, call_next):
+    request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+    request_id_ctx.set(request_id)
+    logger = logging.getLogger("auth-service")
+    logger.info("request", extra={"method": request.method, "path": request.url.path})
+    response = await call_next(request)
+    response.headers["X-Request-ID"] = request_id
+    logger.info("response", extra={"status_code": response.status_code})
+    return response
+
+
+try:  # pragma: no cover - optional tracing
+    from opentelemetry.instrumentation.fastapi import \
+        FastAPIInstrumentor  # type: ignore
+except Exception:  # pragma: no cover
+    FastAPIInstrumentor = None
+
+if FastAPIInstrumentor:  # pragma: no cover - optional tracing
+    FastAPIInstrumentor.instrument_app(app)
 
 
 @app.on_event("startup")

--- a/services/user-service/app/main.py
+++ b/services/user-service/app/main.py
@@ -1,12 +1,78 @@
 from __future__ import annotations
 
-from fastapi import FastAPI
+import json
+import logging
+import uuid
+from contextvars import ContextVar
+
+from fastapi import FastAPI, Request
+from prometheus_client import make_asgi_app
 
 from .api import router
 from .database import Base, engine, get_db
 from .seed import seed_initial_data
 
+request_id_ctx = ContextVar("request_id", default="")
+
+
+class RequestIdFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_ctx.get()
+        return True
+
+
+class JsonFormatter(logging.Formatter):
+    def format(
+        self, record: logging.LogRecord
+    ) -> str:  # pragma: no cover - simple formatting
+        log: dict[str, object] = {
+            "level": record.levelname,
+            "message": record.getMessage(),
+        }
+        if getattr(record, "request_id", ""):
+            log["request_id"] = record.request_id
+        for attr in ("method", "path", "status_code"):
+            if hasattr(record, attr):
+                log[attr] = getattr(record, attr)
+        return json.dumps(log)
+
+
+def setup_logging() -> None:
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    handler.addFilter(RequestIdFilter())
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(logging.INFO)
+
+
+setup_logging()
+
 app = FastAPI()
+metrics_app = make_asgi_app()
+app.mount("/metrics", metrics_app)
+
+
+@app.middleware("http")
+async def add_request_id(request: Request, call_next):
+    request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+    request_id_ctx.set(request_id)
+    logger = logging.getLogger("user-service")
+    logger.info("request", extra={"method": request.method, "path": request.url.path})
+    response = await call_next(request)
+    response.headers["X-Request-ID"] = request_id
+    logger.info("response", extra={"status_code": response.status_code})
+    return response
+
+
+try:  # pragma: no cover - optional tracing
+    from opentelemetry.instrumentation.fastapi import \
+        FastAPIInstrumentor  # type: ignore
+except Exception:  # pragma: no cover
+    FastAPIInstrumentor = None
+
+if FastAPIInstrumentor:  # pragma: no cover - optional tracing
+    FastAPIInstrumentor.instrument_app(app)
 
 
 @app.on_event("startup")


### PR DESCRIPTION
## Summary
- add structured request logging, metrics and tracing hooks to services
- configure Traefik timeouts and Docker healthchecks
- document debugging with Mailhog and pgcli

## Testing
- `pre-commit run --files README.md compose.yml docker/traefik/dynamic.yml services/auth-service/app/main.py services/user-service/app/main.py` *(fails: files were modified by isort)*
- `make typecheck` *(fails: There are no .py[i] files in directory '.')*
- `make test` *(fails: import file mismatch for test_healthz.py)*
- `pytest services/auth-service/tests`
- `pytest services/user-service/tests`


------
https://chatgpt.com/codex/tasks/task_e_689749155b488323a99cb1eed1439b17