### PR TITLE
Add Dockerfiles and compose build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Este arquivo **não deve** ser versionado. Em pipelines de CI/CD, defina as mesm
 variáveis diretamente no ambiente de execução ou utilize mecanismos seguros como
 Docker secrets e configurações da plataforma escolhida.
 
+## Execução com Docker Compose
+
+Para construir as imagens e iniciar todos os serviços, utilize:
+
+```bash
+docker compose build
+docker compose up
+```
+
+As aplicações web e APIs estarão acessíveis em `app.tasks.localhost` e
+`api.tasks.localhost`.
+
 ## Desenvolvimento local no macOS
 
 Para executar a aplicação web localmente em um ambiente macOS:

--- a/compose.yml
+++ b/compose.yml
@@ -43,7 +43,9 @@ services:
       - internal
 
   auth-service:
-    build: ./services/auth-service
+    build:
+      context: .
+      dockerfile: services/auth-service/Dockerfile
     networks:
       - internal
       - traefik
@@ -68,7 +70,9 @@ services:
       - "traefik.http.routers.auth-login.service=auth"
 
   user-service:
-    build: ./services/user-service
+    build:
+      context: .
+      dockerfile: services/user-service/Dockerfile
     networks:
       - internal
       - traefik
@@ -88,7 +92,9 @@ services:
       - "traefik.http.routers.user.middlewares=secure-headers@file,rate-limit@file,cors@file,compress@file"
 
   web:
-    build: ./web
+    build:
+      context: .
+      dockerfile: web/Dockerfile
     networks:
       - internal
       - traefik

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ pytest
 pytest-cov
 httpx
 pydantic-settings
+prometheus-client
+email-validator
 black
 ruff
 mypy

--- a/services/auth-service/Dockerfile
+++ b/services/auth-service/Dockerfile
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY services/auth-service /app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/user-service/Dockerfile
+++ b/services/user-service/Dockerfile
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY services/user-service /app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY web/app/package*.json ./
+RUN npm ci
+
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY web/app ./
+RUN npm run build
+
+FROM node:20-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app ./
+EXPOSE 3000
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- add dockerfiles for auth-service, user-service and web
- document docker compose build usage
- include missing prometheus-client and email-validator dependencies

## Testing
- `pre-commit run --files README.md compose.yml services/auth-service/Dockerfile services/user-service/Dockerfile web/Dockerfile requirements.txt`
- `make typecheck` (fails: There are no .py[i] files in directory '.' )
- `export JWT_PRIVATE_KEY=dummy JWT_PUBLIC_KEY=dummy JWT_KEY_ID=dummy
make test` (fails: module 'app.models' has no attribute 'User')

------
https://chatgpt.com/codex/tasks/task_e_68979451da7083239538282f3910d911