### PR TITLE
fix: add missing frontend libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ eggs/
 lib/
 !frontend_web/lib/
 !frontend_admin/lib/
+!web/app/src/lib/
+!web/app/src/lib/**
 lib64/
 parts/
 sdist/

--- a/web/app/src/app/reset-password/page.tsx
+++ b/web/app/src/app/reset-password/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import api from '@/lib/api';
 import { Form } from '@/components/ui/form';
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Alert } from '@/components/ui/alert';
 
-export default function ResetPasswordPage() {
+function ResetPasswordForm() {
   const search = useSearchParams();
   const token = search.get('token');
   const router = useRouter();
@@ -39,5 +39,13 @@ export default function ResetPasswordPage() {
         <Button type="submit">Redefinir</Button>
       </Form>
     </div>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense fallback={<div />}>
+      <ResetPasswordForm />
+    </Suspense>
   );
 }

--- a/web/app/src/lib/api.ts
+++ b/web/app/src/lib/api.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000',
+  withCredentials: true,
+});
+
+export default api;

--- a/web/app/src/lib/utils.ts
+++ b/web/app/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- add axios api client and utility helper for Tailwind classes
- wrap reset password page in Suspense to support `useSearchParams`
- allow committing web lib files

## Testing
- `pre-commit run --files .gitignore web/app/src/app/reset-password/page.tsx web/app/src/lib/api.ts web/app/src/lib/utils.ts`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68979ae2aa3883239e8a1fca46a6a22e