### PR TITLE
fix: set default API base URL for web

### DIFF
--- a/web/app/src/lib/api.ts
+++ b/web/app/src/lib/api.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000',
+  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://api.tasks.localhost',
   withCredentials: true,
 });
 


### PR DESCRIPTION
## Summary
- fix frontend's default API base URL to use api.tasks.localhost

## Testing
- `pre-commit run --files web/app/src/lib/api.ts`
- `npm test --prefix web/app`
- `pytest` *(fails: AttributeError: module 'app.models' has no attribute 'User')*

------
https://chatgpt.com/codex/tasks/task_e_6897a67124e4832391b489a63ec2e0b7