### PR TITLE
feat: add Traefik router for API root

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -68,6 +68,9 @@ services:
       - "traefik.http.routers.auth-login.priority=100"
       - "traefik.http.routers.auth-login.middlewares=secure-headers@file,rate-limit@file,login-rate-limit@file,cors@file,compress@file"
       - "traefik.http.routers.auth-login.service=auth"
+      - "traefik.http.routers.api-root.rule=Host(`api.tasks.localhost`)"
+      - "traefik.http.routers.api-root.entrypoints=web"
+      - "traefik.http.routers.api-root.service=auth"
 
   user-service:
     build:


### PR DESCRIPTION
## Summary
- add Traefik router to serve API root via auth service

## Testing
- `pre-commit run --files compose.yml`
- `docker compose config` *(fails: command not found: docker)*
- `pytest` *(fails: module 'app.models' has no attribute 'User')*

------
https://chatgpt.com/codex/tasks/task_e_689a352b93f8832389cdc2a419af5765