### PR TITLE
Allow Traefik CORS from app.tasks.localhost

### DIFF
--- a/docker/traefik/dynamic.yml
+++ b/docker/traefik/dynamic.yml
@@ -25,6 +25,7 @@ http:
     cors:
       headers:
         accessControlAllowOriginList:
+          - "http://app.tasks.localhost"
           - "https://app.tasks.localhost"
         accessControlAllowCredentials: true
         addVaryHeader: true


### PR DESCRIPTION
## Summary
- add `http://app.tasks.localhost` to Traefik CORS allowed origins

## Testing
- `pre-commit run --files docker/traefik/dynamic.yml`
- `pytest` *(fails: module 'app.models' has no attribute 'User')*


------
https://chatgpt.com/codex/tasks/task_e_689a35f22a348323b1ccbc4b6892e3e7