### PR TITLE
feat: add auth refresh and protected routes

### DIFF
--- a/web/app/src/app/dashboard/page.tsx
+++ b/web/app/src/app/dashboard/page.tsx
@@ -1,34 +1,16 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { Spinner } from '@/components/ui/spinner';
 import { Badge } from '@/components/ui/badge';
+import withAuth from '@/components/withAuth';
 
-export default function DashboardPage() {
-  const router = useRouter();
-  const [ready, setReady] = useState(false);
-
-  useEffect(() => {
-    const token = localStorage.getItem('accessToken');
-    if (!token) {
-      router.replace('/login');
-    } else {
-      setReady(true);
-    }
-  }, [router]);
-
-  if (!ready) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
-  }
-
+function DashboardPage() {
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold flex items-center gap-2">Dashboard <Badge>Beta</Badge></h1>
+      <h1 className="text-2xl font-bold flex items-center gap-2">
+        Dashboard <Badge>Beta</Badge>
+      </h1>
     </div>
   );
 }
+
+export default withAuth(DashboardPage);

--- a/web/app/src/app/login/page.tsx
+++ b/web/app/src/app/login/page.tsx
@@ -7,50 +7,61 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
 import { Card, CardContent } from '@/components/ui/card';
+import { Alert } from '@/components/ui/alert';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
   const router = useRouter();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setError('');
     try {
       const res = await api.post('/auth/login', { email, password });
       const { accessToken, refreshToken } = res.data;
       localStorage.setItem('accessToken', accessToken);
       localStorage.setItem('refreshToken', refreshToken);
       router.push('/dashboard');
-    } catch (err) {
+    } catch (err: unknown) {
       console.error(err);
-      alert('Login failed');
+      const message =
+        typeof err === 'object' &&
+        err !== null &&
+        'response' in err &&
+        (err as { response?: { data?: { message?: string } } }).response?.data?.message
+          ? (err as { response?: { data?: { message?: string } } }).response!.data!.message!
+          : 'Falha no login';
+      setError(message);
     }
   };
 
   return (
     <div className="flex min-h-screen items-center justify-center">
-      <Card className="w-80">
-        <CardContent>
-          <Form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <Input
-              placeholder="Email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-            />
-            <Input
-              placeholder="Password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
-            <Button type="submit">Login</Button>
-            <a href="/forgot-password" className="text-sm text-blue-500 self-end">
-              Esqueceu a senha?
-            </a>
-          </Form>
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
+        <Card className="w-80">
+          <CardContent>
+            <Form onSubmit={handleSubmit} className="flex flex-col gap-4">
+              {error && <Alert>{error}</Alert>}
+              <Input
+                placeholder="Email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+              <Input
+                placeholder="Password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+              <Button type="submit">Login</Button>
+              <a href="/forgot-password" className="text-sm text-blue-500 self-end">
+                Esqueceu a senha?
+              </a>
+            </Form>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }

--- a/web/app/src/components/withAuth.tsx
+++ b/web/app/src/components/withAuth.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { Spinner } from '@/components/ui/spinner';
+
+export default function withAuth<T>(Component: React.ComponentType<T>) {
+  return function AuthenticatedComponent(props: T) {
+    const router = useRouter();
+    const [checking, setChecking] = useState(true);
+
+    useEffect(() => {
+      const token = typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null;
+      if (!token) {
+        router.replace('/login');
+      } else {
+        setChecking(false);
+      }
+    }, [router]);
+
+    if (checking) {
+      return (
+        <div className="flex min-h-screen items-center justify-center">
+          <Spinner />
+        </div>
+      );
+    }
+
+    return <Component {...props} />;
+  };
+}


### PR DESCRIPTION
## Summary
- refresh tokens automatically via axios interceptors
- display login errors with styled alert
- add withAuth HOC to protect dashboard route

## Testing
- `pre-commit run --files web/app/src/app/dashboard/page.tsx web/app/src/app/login/page.tsx web/app/src/lib/api.ts web/app/src/components/withAuth.tsx`
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_689a3cdb3ef8832394dd2312259565b3