### PR TITLE
feat: add granular user role permissions and admin UI

### DIFF
--- a/services/user-service/app/seed.py
+++ b/services/user-service/app/seed.py
@@ -8,7 +8,13 @@ from . import models
 def seed_initial_data(db: Session) -> None:
     # Seed roles
     if not db.query(models.Role).first():
-        db.add_all([models.Role(name="admin"), models.Role(name="user")])
+        db.add_all(
+            [
+                models.Role(name="admin"),
+                models.Role(name="manager"),
+                models.Role(name="user"),
+            ]
+        )
         db.commit()
     # Seed sectors
     if not db.query(models.Sector).first():

--- a/services/user-service/tests/test_users.py
+++ b/services/user-service/tests/test_users.py
@@ -33,16 +33,115 @@ def test_users_me_and_sectors_seed(client):
     assert any(s["name"] == "Gerente" for s in data["sectors"])
 
 
-def test_get_users_requires_admin(client):
+def test_get_users_requires_admin_or_manager(client):
     from app import models
     from app.database import SessionLocal
 
     db = SessionLocal()
     admin = db.query(models.User).filter_by(email="admin@example.com").first()
     db.close()
-    token = create_token(str(admin.id), ["user"])  # not admin
+    token = create_token(str(admin.id), ["user"])  # not admin or manager
     res = client.get("/users", headers={"Authorization": f"Bearer {token}"})
     assert res.status_code == 403
+
+
+def get_manager_token(client) -> str:
+    import uuid
+
+    admin_token = get_admin_token()
+    email = f"manager{uuid.uuid4().hex}@example.com"
+    res = client.post(
+        "/users",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "email": email,
+            "full_name": "Manager",
+            "roles": ["manager"],
+            "sectors": [],
+        },
+    )
+    assert res.status_code == 201
+    manager_id = res.json()["id"]
+    return create_token(manager_id, ["manager"])
+
+
+def test_manager_can_list_and_create_collaborator(client):
+    manager_token = get_manager_token(client)
+    res_list = client.get(
+        "/users", headers={"Authorization": f"Bearer {manager_token}"}
+    )
+    assert res_list.status_code == 200
+    res_create = client.post(
+        "/users",
+        headers={"Authorization": f"Bearer {manager_token}"},
+        json={
+            "email": "collab@example.com",
+            "full_name": "Collab",
+            "roles": ["user"],
+            "sectors": [],
+        },
+    )
+    assert res_create.status_code == 201
+
+
+def test_manager_cannot_create_admin(client):
+    manager_token = get_manager_token(client)
+    res = client.post(
+        "/users",
+        headers={"Authorization": f"Bearer {manager_token}"},
+        json={
+            "email": "badadmin@example.com",
+            "full_name": "Bad",
+            "roles": ["admin"],
+            "sectors": [],
+        },
+    )
+    assert res.status_code == 403
+
+
+def test_manager_update_permissions(client):
+    admin_token = get_admin_token()
+    manager_token = get_manager_token(client)
+    res_collab = client.post(
+        "/users",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "email": "tocollab@example.com",
+            "full_name": "To Collab",
+            "roles": ["user"],
+            "sectors": [],
+        },
+    )
+    collab_id = res_collab.json()["id"]
+    res_update = client.patch(
+        f"/users/{collab_id}",
+        headers={"Authorization": f"Bearer {manager_token}"},
+        json={"full_name": "Updated"},
+    )
+    assert res_update.status_code == 200
+    res_promote = client.patch(
+        f"/users/{collab_id}",
+        headers={"Authorization": f"Bearer {manager_token}"},
+        json={"roles": ["admin"]},
+    )
+    assert res_promote.status_code == 403
+    res_admin = client.post(
+        "/users",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={
+            "email": "otheradmin@example.com",
+            "full_name": "Other Admin",
+            "roles": ["admin"],
+            "sectors": [],
+        },
+    )
+    admin_id = res_admin.json()["id"]
+    res_fail = client.patch(
+        f"/users/{admin_id}",
+        headers={"Authorization": f"Bearer {manager_token}"},
+        json={"full_name": "x"},
+    )
+    assert res_fail.status_code == 403
 
 
 def test_create_and_list_users_with_pagination(client):
@@ -105,7 +204,9 @@ def test_roles_and_sectors_endpoints(client):
     admin_token = get_admin_token()
     res_roles = client.get("/roles", headers={"Authorization": f"Bearer {admin_token}"})
     assert res_roles.status_code == 200
-    assert any(r["name"] == "admin" for r in res_roles.json())
+    data_roles = res_roles.json()
+    assert any(r["name"] == "admin" for r in data_roles)
+    assert any(r["name"] == "manager" for r in data_roles)
     res_sectors = client.get(
         "/sectors", headers={"Authorization": f"Bearer {admin_token}"}
     )

--- a/web/app/src/app/admin/users/page.tsx
+++ b/web/app/src/app/admin/users/page.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useEffect, useState, FormEvent } from 'react';
+import withAuth from '@/components/withAuth';
+import api from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface Role {
+  name: string;
+}
+
+interface User {
+  id: string;
+  email: string;
+  full_name: string | null;
+  roles: Role[];
+}
+
+function UsersAdminPage() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [roles, setRoles] = useState<string[]>([]);
+  const [form, setForm] = useState({
+    id: '' as string | null,
+    email: '',
+    full_name: '',
+    roles: ['user'] as string[],
+  });
+
+  useEffect(() => {
+    void fetchUsers();
+    void fetchRoles();
+  }, []);
+
+  async function fetchUsers() {
+    const res = await api.get('/users');
+    setUsers(res.data);
+  }
+
+  async function fetchRoles() {
+    const res = await api.get('/roles');
+    setRoles(res.data.map((r: Role) => r.name));
+  }
+
+  function startEdit(user: User) {
+    setForm({
+      id: user.id,
+      email: user.email,
+      full_name: user.full_name || '',
+      roles: user.roles.map((r) => r.name),
+    });
+  }
+
+  function resetForm() {
+    setForm({ id: '', email: '', full_name: '', roles: ['user'] });
+  }
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (form.id) {
+      await api.patch(`/users/${form.id}`, {
+        full_name: form.full_name,
+        roles: form.roles,
+      });
+    } else {
+      await api.post('/users', {
+        email: form.email,
+        full_name: form.full_name,
+        roles: form.roles,
+        sectors: [],
+      });
+    }
+    resetForm();
+    await fetchUsers();
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">User Management</h1>
+      <form onSubmit={onSubmit} className="space-y-2 max-w-md">
+        {!form.id && (
+          <Input
+            placeholder="Email"
+            value={form.email}
+            onChange={(e) => setForm({ ...form, email: e.target.value })}
+          />
+        )}
+        <Input
+          placeholder="Full name"
+          value={form.full_name}
+          onChange={(e) => setForm({ ...form, full_name: e.target.value })}
+        />
+        <select
+          multiple
+          className="border rounded p-2 w-full"
+          value={form.roles}
+          onChange={(e) =>
+            setForm({
+              ...form,
+              roles: Array.from(e.target.selectedOptions).map((o) => o.value),
+            })
+          }
+        >
+          {roles.map((role) => (
+            <option key={role} value={role}>
+              {role}
+            </option>
+          ))}
+        </select>
+        <Button type="submit">{form.id ? 'Update' : 'Create'}</Button>
+        {form.id && (
+          <Button type="button" variant="ghost" onClick={resetForm}>
+            Cancel
+          </Button>
+        )}
+      </form>
+      <ul className="space-y-1">
+        {users.map((u) => (
+          <li key={u.id} className="flex justify-between items-center">
+            <span>{u.email}</span>
+            <Button type="button" variant="outline" onClick={() => startEdit(u)}>
+              Edit
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default withAuth(UsersAdminPage);


### PR DESCRIPTION
## Summary
- seed manager role and expand require_roles to restrict role assignment
- allow managers to manage collaborators via API and add admin UI for managing users
- cover manager permissions with new tests

## Testing
- `pre-commit run --files services/user-service/app/seed.py services/user-service/app/security.py services/user-service/app/api.py services/user-service/tests/test_users.py web/app/src/app/admin/users/page.tsx`
- `pytest services/user-service`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a3f33e5f08323ace0911b093cca04