### PR TITLE
Add async database setup and migration script

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,4 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///./tasks.db
+version_table_schema = tasks

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import sys
+from logging.config import fileConfig
+from pathlib import Path
+
+from sqlalchemy import engine_from_config, pool, text
+
+from alembic import context
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from task_service.core.database import Base  # noqa: E402
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+schema = config.get_main_option("version_table_schema", "public")
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        version_table_schema=schema,
+        include_schemas=True,
+        literal_binds=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        if connection.dialect.name == "postgresql":
+            connection.execute(text(f"SET search_path TO {schema}"))
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            version_table_schema=schema,
+            include_schemas=True,
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+alembic upgrade head

--- a/task_service/core/database.py
+++ b/task_service/core/database.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+from sqlalchemy import MetaData
+from sqlalchemy.ext.asyncio import (AsyncSession, async_sessionmaker,
+                                    create_async_engine)
+from sqlalchemy.orm import DeclarativeBase
+
+from .settings import settings
+
+metadata = MetaData(schema="tasks")
+
+
+class Base(DeclarativeBase):
+    """Base declarative class for all models."""
+
+    metadata = metadata
+
+
+engine = create_async_engine(str(settings.tasks_database_url))
+async_session_factory = async_sessionmaker(
+    engine, expire_on_commit=False, class_=AsyncSession
+)
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    """Provide a transactional scope around a series of operations."""
+    async with async_session_factory() as session:
+        yield session


### PR DESCRIPTION
## Summary
- add async SQLAlchemy engine and session for tasks service
- configure Alembic for tasks schema and add migration script

## Testing
- `pre-commit run --files task_service/core/database.py alembic.ini alembic/env.py scripts/migrate.sh`
- `pytest` *(fails: AttributeError: module 'app.models' has no attribute 'Sector')*


------
https://chatgpt.com/codex/tasks/task_e_689a4a67300483239d4c166bcd22fd6d