### PR TITLE
Fix generic constraint in withAuth HOC to restore Next.js build

### DIFF
--- a/web/app/src/components/withAuth.tsx
+++ b/web/app/src/components/withAuth.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { Spinner } from '@/components/ui/spinner';
 
-export default function withAuth<T>(Component: React.ComponentType<T>) {
+export default function withAuth<T extends object>(Component: React.ComponentType<T>) {
   return function AuthenticatedComponent(props: T) {
     const router = useRouter();
     const [checking, setChecking] = useState(true);


### PR DESCRIPTION
## Summary
- ensure withAuth HOC props extend object so React intrinsic attributes are satisfied

## Testing
- `npm run lint`
- `npm test`
- `pre-commit run --files web/app/src/components/withAuth.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a4cc9a16483238442965e5fc822bf