### PR TITLE
feat: add project and task models with migrations

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -11,11 +11,15 @@ from alembic import context
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from task_service.core.database import Base  # noqa: E402
+from task_service.domain import models  # noqa: E402,F401
 
 config = context.config
 
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    try:
+        fileConfig(config.config_file_name)
+    except KeyError:
+        pass
 
 target_metadata = Base.metadata
 schema = config.get_main_option("version_table_schema", "public")

--- a/alembic/versions/0001_create_projects_tasks.py
+++ b/alembic/versions/0001_create_projects_tasks.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0001_create_projects_tasks"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+    schema = "tasks" if dialect != "sqlite" else None
+
+    if dialect == "postgresql":
+        op.execute(
+            sa.schema.CreateSequence(sa.Sequence("projects_id_seq", schema="tasks"))
+        )
+        op.execute(
+            sa.schema.CreateSequence(sa.Sequence("tasks_id_seq", schema="tasks"))
+        )
+
+    op.create_table(
+        "projects",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("slug", sa.String(), nullable=False, unique=True),
+        sa.Column(
+            "created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()
+        ),
+        schema=schema,
+    )
+
+    op.create_table(
+        "tasks",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.Integer(),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False, server_default="pending"),
+        sa.Column("tags", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()
+        ),
+        schema=schema,
+    )
+
+    op.create_index(
+        "ix_projects_slug", "projects", ["slug"], unique=True, schema=schema
+    )
+    op.create_index(
+        "ix_tasks_project_status", "tasks", ["project_id", "status"], schema=schema
+    )
+    if dialect == "postgresql":
+        op.create_index(
+            "ix_tasks_tags",
+            "tasks",
+            ["tags"],
+            postgresql_using="gin",
+            schema=schema,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+    schema = "tasks" if dialect != "sqlite" else None
+
+    if dialect == "postgresql":
+        op.drop_index("ix_tasks_tags", table_name="tasks", schema=schema)
+    op.drop_index("ix_tasks_project_status", table_name="tasks", schema=schema)
+    op.drop_index("ix_projects_slug", table_name="projects", schema=schema)
+    op.drop_table("tasks", schema=schema)
+    op.drop_table("projects", schema=schema)
+
+    if dialect == "postgresql":
+        op.execute(sa.schema.DropSequence(sa.Sequence("tasks_id_seq", schema="tasks")))
+        op.execute(
+            sa.schema.DropSequence(sa.Sequence("projects_id_seq", schema="tasks"))
+        )

--- a/task_service/domain/models.py
+++ b/task_service/domain/models.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from task_service.core.database import Base
+
+
+class Project(Base):
+    __tablename__ = "projects"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    slug: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    tasks: Mapped[list["Task"]] = relationship("Task", back_populates="project")
+
+
+class Task(Base):
+    __tablename__ = "tasks"
+    __table_args__ = (
+        Index("ix_tasks_project_status", "project_id", "status"),
+        Index("ix_tasks_tags", "tags", postgresql_using="gin"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    project_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("projects.id", ondelete="CASCADE"), nullable=False
+    )
+    title: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(String, nullable=False, default="pending")
+    tags: Mapped[Optional[list[str]]] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    project: Mapped[Project] = relationship("Project", back_populates="tasks")


### PR DESCRIPTION
## Summary
- define Project and Task models with optional GIN index for tags
- add Alembic migration creating tables, sequences, and indexes
- update Alembic env to load new models and handle missing logging config

## Testing
- `pre-commit run --files alembic/env.py alembic/versions/0001_create_projects_tasks.py task_service/domain/models.py`
- `make typecheck` *(fails: Settings assignments incompatible; engine_from_config arg type)*
- `make test` *(fails: AttributeError module 'app.models' has no attribute 'User')*

------
https://chatgpt.com/codex/tasks/task_e_689a4cda2d9c83238d23146ff44ab606