### PR TITLE
feat: add async repositories for domain entities

### DIFF
--- a/task_service/domain/models.py
+++ b/task_service/domain/models.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
-from sqlalchemy import JSON, DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import (
+    JSON,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from task_service.core.database import Base
@@ -21,6 +29,7 @@ class Project(Base):
     )
 
     tasks: Mapped[list["Task"]] = relationship("Task", back_populates="project")
+    lists: Mapped[list["List"]] = relationship("List", back_populates="project")
 
 
 class Task(Base):
@@ -34,13 +43,78 @@ class Task(Base):
     project_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("projects.id", ondelete="CASCADE"), nullable=False
     )
+    list_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("lists.id", ondelete="SET NULL"), nullable=True
+    )
     title: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     status: Mapped[str] = mapped_column(String, nullable=False, default="pending")
-    tags: Mapped[Optional[list[str]]] = mapped_column(JSON, nullable=True)
+    complexity: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    priority: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    start_date: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    due_date: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    tags: Mapped[list[str]] = mapped_column(JSON, default=list)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
     )
 
     project: Mapped[Project] = relationship("Project", back_populates="tasks")
+    list: Mapped[Optional["List"]] = relationship("List", back_populates="tasks")
+    comments: Mapped[list["Comment"]] = relationship(
+        "Comment", back_populates="task", cascade="all, delete-orphan"
+    )
+    activity_logs: Mapped[list["ActivityLog"]] = relationship(
+        "ActivityLog", back_populates="task", cascade="all, delete-orphan"
+    )
+
+
+class List(Base):
+    __tablename__ = "lists"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    project_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("projects.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    order: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    project: Mapped[Project] = relationship("Project", back_populates="lists")
+    tasks: Mapped[list[Task]] = relationship("Task", back_populates="list")
+
+
+class Comment(Base):
+    __tablename__ = "comments"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    task_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("tasks.id", ondelete="CASCADE"), nullable=False
+    )
+    author_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    task: Mapped[Task] = relationship("Task", back_populates="comments")
+
+
+class ActivityLog(Base):
+    __tablename__ = "activity_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    task_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("tasks.id", ondelete="SET NULL"), nullable=True
+    )
+    action: Mapped[str] = mapped_column(String, nullable=False)
+    performed_by: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    details: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    task: Mapped[Optional[Task]] = relationship("Task", back_populates="activity_logs")

--- a/task_service/repositories/__init__.py
+++ b/task_service/repositories/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from .activity import ActivityLogRepository
+from .comments import CommentRepository
+from .lists import ListRepository
+from .projects import ProjectRepository
+from .tasks import TaskRepository
+
+__all__ = [
+    "ProjectRepository",
+    "ListRepository",
+    "TaskRepository",
+    "CommentRepository",
+    "ActivityLogRepository",
+]

--- a/task_service/repositories/activity.py
+++ b/task_service/repositories/activity.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from task_service.domain.models import ActivityLog
+from task_service.domain.schemas import ActivityLogCreate
+
+
+class ActivityLogRepository:
+    async def create(
+        self, session: AsyncSession, activity_in: ActivityLogCreate
+    ) -> ActivityLog:
+        activity = ActivityLog(**activity_in.model_dump())
+        session.add(activity)
+        await session.commit()
+        await session.refresh(activity)
+        return activity
+
+    async def get(self, session: AsyncSession, activity_id: int) -> Optional[ActivityLog]:
+        return await session.get(ActivityLog, activity_id)
+
+    async def list(
+        self,
+        session: AsyncSession,
+        *,
+        task_id: Optional[int] = None,
+        performed_by: Optional[int] = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> list[ActivityLog]:
+        stmt: Select[tuple[ActivityLog]] = select(ActivityLog)
+        if task_id is not None:
+            stmt = stmt.where(ActivityLog.task_id == task_id)
+        if performed_by is not None:
+            stmt = stmt.where(ActivityLog.performed_by == performed_by)
+        stmt = stmt.order_by(ActivityLog.created_at.desc()).offset(offset).limit(limit)
+        result = await session.execute(stmt)
+        return result.scalars().all()
+
+    async def delete(self, session: AsyncSession, activity_id: int) -> bool:
+        activity = await self.get(session, activity_id)
+        if not activity:
+            return False
+        await session.delete(activity)
+        await session.commit()
+        return True
+
+    async def count_by_action(
+        self, session: AsyncSession, *, task_id: Optional[int] = None
+    ) -> dict[str, int]:
+        stmt = select(ActivityLog.action, func.count(ActivityLog.id)).group_by(
+            ActivityLog.action
+        )
+        if task_id is not None:
+            stmt = stmt.where(ActivityLog.task_id == task_id)
+        result = await session.execute(stmt)
+        return {action: count for action, count in result.all()}

--- a/task_service/repositories/comments.py
+++ b/task_service/repositories/comments.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from task_service.domain.models import Comment
+from task_service.domain.schemas import CommentCreate
+
+
+class CommentRepository:
+    async def create(
+        self, session: AsyncSession, comment_in: CommentCreate
+    ) -> Comment:
+        comment = Comment(**comment_in.model_dump())
+        session.add(comment)
+        await session.commit()
+        await session.refresh(comment)
+        return comment
+
+    async def get(self, session: AsyncSession, comment_id: int) -> Optional[Comment]:
+        return await session.get(Comment, comment_id)
+
+    async def list_by_task(
+        self,
+        session: AsyncSession,
+        task_id: int,
+        *,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> list[Comment]:
+        stmt: Select[tuple[Comment]] = (
+            select(Comment)
+            .where(Comment.task_id == task_id)
+            .order_by(Comment.created_at)
+            .offset(offset)
+            .limit(limit)
+        )
+        result = await session.execute(stmt)
+        return result.scalars().all()
+
+    async def update(
+        self, session: AsyncSession, comment_id: int, data: dict[str, Any]
+    ) -> Optional[Comment]:
+        comment = await self.get(session, comment_id)
+        if not comment:
+            return None
+        for key, value in data.items():
+            setattr(comment, key, value)
+        await session.commit()
+        await session.refresh(comment)
+        return comment
+
+    async def delete(self, session: AsyncSession, comment_id: int) -> bool:
+        comment = await self.get(session, comment_id)
+        if not comment:
+            return False
+        await session.delete(comment)
+        await session.commit()
+        return True
+
+    async def count_by_task(self, session: AsyncSession, task_id: int) -> int:
+        stmt = select(func.count(Comment.id)).where(Comment.task_id == task_id)
+        result = await session.execute(stmt)
+        return result.scalar_one()

--- a/task_service/repositories/lists.py
+++ b/task_service/repositories/lists.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from task_service.domain.models import List, Task
+from task_service.domain.schemas import ListCreate
+
+
+class ListRepository:
+    async def create(self, session: AsyncSession, list_in: ListCreate) -> List:
+        lst = List(**list_in.model_dump())
+        session.add(lst)
+        await session.commit()
+        await session.refresh(lst)
+        return lst
+
+    async def get(self, session: AsyncSession, list_id: int) -> Optional[List]:
+        return await session.get(List, list_id)
+
+    async def list_by_project(
+        self,
+        session: AsyncSession,
+        project_id: int,
+        *,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> list[List]:
+        stmt: Select[tuple[List]] = (
+            select(List)
+            .where(List.project_id == project_id)
+            .order_by(List.order)
+            .offset(offset)
+            .limit(limit)
+        )
+        result = await session.execute(stmt)
+        return result.scalars().all()
+
+    async def update(
+        self, session: AsyncSession, list_id: int, data: dict[str, Any]
+    ) -> Optional[List]:
+        lst = await self.get(session, list_id)
+        if not lst:
+            return None
+        for key, value in data.items():
+            setattr(lst, key, value)
+        await session.commit()
+        await session.refresh(lst)
+        return lst
+
+    async def delete(self, session: AsyncSession, list_id: int) -> bool:
+        lst = await self.get(session, list_id)
+        if not lst:
+            return False
+        await session.delete(lst)
+        await session.commit()
+        return True
+
+    async def task_count(self, session: AsyncSession, list_id: int) -> int:
+        stmt = select(func.count(Task.id)).where(Task.list_id == list_id)
+        result = await session.execute(stmt)
+        return result.scalar_one()

--- a/task_service/repositories/projects.py
+++ b/task_service/repositories/projects.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from task_service.domain.models import Project, Task
+from task_service.domain.schemas import ProjectCreate
+
+
+class ProjectRepository:
+    """Data access layer for :class:`~task_service.domain.models.Project`."""
+
+    async def create(
+        self, session: AsyncSession, project_in: ProjectCreate
+    ) -> Project:
+        project = Project(**project_in.model_dump())
+        session.add(project)
+        await session.commit()
+        await session.refresh(project)
+        return project
+
+    async def get(self, session: AsyncSession, project_id: int) -> Optional[Project]:
+        return await session.get(Project, project_id)
+
+    async def get_by_slug(
+        self, session: AsyncSession, slug: str
+    ) -> Optional[Project]:
+        stmt: Select[tuple[Project]] = select(Project).where(Project.slug == slug)
+        result = await session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def list(
+        self, session: AsyncSession, *, offset: int = 0, limit: int = 100
+    ) -> list[Project]:
+        stmt: Select[tuple[Project]] = select(Project).offset(offset).limit(limit)
+        result = await session.execute(stmt)
+        return result.scalars().all()
+
+    async def update(
+        self,
+        session: AsyncSession,
+        project_id: int,
+        data: dict[str, Any],
+    ) -> Optional[Project]:
+        project = await self.get(session, project_id)
+        if not project:
+            return None
+        for key, value in data.items():
+            setattr(project, key, value)
+        await session.commit()
+        await session.refresh(project)
+        return project
+
+    async def delete(self, session: AsyncSession, project_id: int) -> bool:
+        project = await self.get(session, project_id)
+        if not project:
+            return False
+        await session.delete(project)
+        await session.commit()
+        return True
+
+    async def task_statistics(
+        self, session: AsyncSession, project_id: int
+    ) -> dict[str, int]:
+        stmt = (
+            select(Task.status, func.count(Task.id))
+            .where(Task.project_id == project_id)
+            .group_by(Task.status)
+        )
+        result = await session.execute(stmt)
+        return {status: count for status, count in result.all()}

--- a/task_service/repositories/tasks.py
+++ b/task_service/repositories/tasks.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from task_service.domain.models import Task
+from task_service.domain.schemas import TaskCreate
+
+
+class TaskRepository:
+    async def create(self, session: AsyncSession, task_in: TaskCreate) -> Task:
+        task = Task(**task_in.model_dump())
+        session.add(task)
+        await session.commit()
+        await session.refresh(task)
+        return task
+
+    async def get(self, session: AsyncSession, task_id: int) -> Optional[Task]:
+        return await session.get(Task, task_id)
+
+    async def list(
+        self,
+        session: AsyncSession,
+        *,
+        project_id: Optional[int] = None,
+        list_id: Optional[int] = None,
+        status: Optional[str] = None,
+        tag: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> list[Task]:
+        stmt: Select[tuple[Task]] = select(Task)
+        if project_id is not None:
+            stmt = stmt.where(Task.project_id == project_id)
+        if list_id is not None:
+            stmt = stmt.where(Task.list_id == list_id)
+        if status is not None:
+            stmt = stmt.where(Task.status == status)
+        if tag is not None:
+            stmt = stmt.where(Task.tags.contains([tag]))
+        stmt = stmt.offset(offset).limit(limit)
+        result = await session.execute(stmt)
+        return result.scalars().all()
+
+    async def update(
+        self, session: AsyncSession, task_id: int, data: dict[str, Any]
+    ) -> Optional[Task]:
+        task = await self.get(session, task_id)
+        if not task:
+            return None
+        for key, value in data.items():
+            setattr(task, key, value)
+        await session.commit()
+        await session.refresh(task)
+        return task
+
+    async def delete(self, session: AsyncSession, task_id: int) -> bool:
+        task = await self.get(session, task_id)
+        if not task:
+            return False
+        await session.delete(task)
+        await session.commit()
+        return True
+
+    async def count_by_status(
+        self, session: AsyncSession, *, project_id: Optional[int] = None
+    ) -> dict[str, int]:
+        stmt = select(Task.status, func.count(Task.id)).group_by(Task.status)
+        if project_id is not None:
+            stmt = stmt.where(Task.project_id == project_id)
+        result = await session.execute(stmt)
+        return {status: count for status, count in result.all()}


### PR DESCRIPTION
## Summary
- add ORM models for lists, comments and activity logs
- implement async CRUD repositories with filtering and stats

## Testing
- `pytest` *(fails: AttributeError: module 'app.models' has no attribute 'User')*


------
https://chatgpt.com/codex/tasks/task_e_689a51fc7300832391b7123193afac6e