### PR TITLE
feat: add task service layer

### DIFF
--- a/task_service/domain/models.py
+++ b/task_service/domain/models.py
@@ -3,15 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Optional
 
-from sqlalchemy import (
-    JSON,
-    DateTime,
-    ForeignKey,
-    Index,
-    Integer,
-    String,
-    Text,
-)
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from task_service.core.database import Base
@@ -54,6 +46,9 @@ class Task(Base):
     start_date: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     due_date: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    code: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    assignee_ids: Mapped[list[int]] = mapped_column(JSON, default=list)
+    sector_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     tags: Mapped[list[str]] = mapped_column(JSON, default=list)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(

--- a/task_service/domain/schemas.py
+++ b/task_service/domain/schemas.py
@@ -77,6 +77,8 @@ class TaskBase(BaseModel):
     start_date: datetime | None = None
     due_date: datetime | None = None
     completed_at: datetime | None = None
+    assignee_ids: list[int] = []
+    sector_id: int | None = None
     tags: list[str] = []
 
     @model_validator(mode="after")
@@ -96,13 +98,18 @@ class TaskBase(BaseModel):
 
 
 class TaskCreate(TaskBase):
-    pass
+    code: str | None = None
 
 
 class TaskRead(TaskBase):
     id: int
+    code: str
     created_at: datetime
     updated_at: datetime
+    timeliness: str | None = None
+    days_total: int | None = None
+    days_elapsed: int | None = None
+    days_remaining: int | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/task_service/repositories/tasks.py
+++ b/task_service/repositories/tasks.py
@@ -72,3 +72,8 @@ class TaskRepository:
             stmt = stmt.where(Task.project_id == project_id)
         result = await session.execute(stmt)
         return {status: count for status, count in result.all()}
+
+    async def count_in_project(self, session: AsyncSession, project_id: int) -> int:
+        stmt = select(func.count(Task.id)).where(Task.project_id == project_id)
+        result = await session.execute(stmt)
+        return result.scalar_one()

--- a/task_service/services/__init__.py
+++ b/task_service/services/__init__.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from .comments import CommentService
+from .lists import ListService
+from .projects import ProjectService
+from .tasks import TaskService
+
+__all__ = [
+    "ProjectService",
+    "ListService",
+    "TaskService",
+    "CommentService",
+]

--- a/task_service/services/comments.py
+++ b/task_service/services/comments.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from task_service.domain.models import Comment
+from task_service.domain.schemas import CommentCreate
+from task_service.repositories import CommentRepository
+
+
+class CommentService:
+    """Business logic for :class:`~task_service.domain.models.Comment`."""
+
+    def __init__(self, repository: CommentRepository | None = None) -> None:
+        self.repository = repository or CommentRepository()
+
+    async def create(self, session: AsyncSession, comment_in: CommentCreate) -> Comment:
+        return await self.repository.create(session, comment_in)
+
+    async def get(self, session: AsyncSession, comment_id: int) -> Optional[Comment]:
+        return await self.repository.get(session, comment_id)
+
+    async def list_by_task(
+        self, session: AsyncSession, task_id: int, *, offset: int = 0, limit: int = 100
+    ) -> list[Comment]:
+        return await self.repository.list_by_task(
+            session, task_id, offset=offset, limit=limit
+        )
+
+    async def update(
+        self, session: AsyncSession, comment_id: int, data: dict[str, Any]
+    ) -> Optional[Comment]:
+        return await self.repository.update(session, comment_id, data)
+
+    async def delete(self, session: AsyncSession, comment_id: int) -> bool:
+        return await self.repository.delete(session, comment_id)
+
+    async def count_by_task(self, session: AsyncSession, task_id: int) -> int:
+        return await self.repository.count_by_task(session, task_id)

--- a/task_service/services/lists.py
+++ b/task_service/services/lists.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from task_service.domain.models import List
+from task_service.domain.schemas import ListCreate
+from task_service.repositories import ListRepository
+
+
+class ListService:
+    """Business logic for :class:`~task_service.domain.models.List`."""
+
+    def __init__(self, repository: ListRepository | None = None) -> None:
+        self.repository = repository or ListRepository()
+
+    async def create(self, session: AsyncSession, list_in: ListCreate) -> List:
+        return await self.repository.create(session, list_in)
+
+    async def get(self, session: AsyncSession, list_id: int) -> Optional[List]:
+        return await self.repository.get(session, list_id)
+
+    async def list_by_project(
+        self,
+        session: AsyncSession,
+        project_id: int,
+        *,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> list[List]:
+        return await self.repository.list_by_project(
+            session, project_id, offset=offset, limit=limit
+        )
+
+    async def update(
+        self, session: AsyncSession, list_id: int, data: dict[str, Any]
+    ) -> Optional[List]:
+        return await self.repository.update(session, list_id, data)
+
+    async def delete(self, session: AsyncSession, list_id: int) -> bool:
+        return await self.repository.delete(session, list_id)
+
+    async def task_count(self, session: AsyncSession, list_id: int) -> int:
+        return await self.repository.task_count(session, list_id)

--- a/task_service/services/projects.py
+++ b/task_service/services/projects.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from task_service.domain.models import Project
+from task_service.domain.schemas import ProjectCreate
+from task_service.repositories import ProjectRepository
+
+
+class ProjectService:
+    """Business logic for :class:`~task_service.domain.models.Project`."""
+
+    def __init__(self, repository: ProjectRepository | None = None) -> None:
+        self.repository = repository or ProjectRepository()
+
+    async def create(self, session: AsyncSession, project_in: ProjectCreate) -> Project:
+        return await self.repository.create(session, project_in)
+
+    async def get(self, session: AsyncSession, project_id: int) -> Optional[Project]:
+        return await self.repository.get(session, project_id)
+
+    async def get_by_slug(self, session: AsyncSession, slug: str) -> Optional[Project]:
+        return await self.repository.get_by_slug(session, slug)
+
+    async def list(
+        self, session: AsyncSession, *, offset: int = 0, limit: int = 100
+    ) -> list[Project]:
+        return await self.repository.list(session, offset=offset, limit=limit)
+
+    async def update(
+        self, session: AsyncSession, project_id: int, data: dict[str, Any]
+    ) -> Optional[Project]:
+        return await self.repository.update(session, project_id, data)
+
+    async def delete(self, session: AsyncSession, project_id: int) -> bool:
+        return await self.repository.delete(session, project_id)
+
+    async def task_statistics(
+        self, session: AsyncSession, project_id: int
+    ) -> dict[str, int]:
+        return await self.repository.task_statistics(session, project_id)


### PR DESCRIPTION
## Summary
- add CRUD services for projects, lists, tasks, and comments
- generate task code per project and compute timing metrics
- validate assignee and sector data with the user service

## Testing
- `pre-commit run --files task_service/domain/models.py task_service/domain/schemas.py task_service/repositories/tasks.py task_service/services/__init__.py task_service/services/comments.py task_service/services/lists.py task_service/services/projects.py task_service/services/tasks.py`
- `mypy task_service/domain/models.py task_service/domain/schemas.py task_service/repositories/tasks.py task_service/services/__init__.py task_service/services/comments.py task_service/services/lists.py task_service/services/projects.py task_service/services/tasks.py --follow-imports=skip --ignore-missing-imports`
- `make test` *(fails: AttributeError: module 'app.models' has no attribute 'Role')*

------
https://chatgpt.com/codex/tasks/task_e_689a53eff8c0832383cda1a4c1e95a4a