### PR TITLE
feat: add token validation using jwks

### DIFF
--- a/task_service/core/security.py
+++ b/task_service/core/security.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from .settings import settings
+
+JWKS_CACHE_TTL_SECONDS = 600
+_jwks_cache: dict[str, tuple[dict[str, Any], float]] = {}
+
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+async def _get_jwk(kid: str) -> dict[str, Any]:
+    cached = _jwks_cache.get(kid)
+    now = time.time()
+    if cached and cached[1] > now:
+        return cached[0]
+
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.get(str(settings.auth_jwks_url))
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Could not fetch JWKS",
+            ) from exc
+    jwks = resp.json()
+    for jwk in jwks.get("keys", []):
+        if jwk.get("kid") == kid:
+            _jwks_cache[kid] = (jwk, now + JWKS_CACHE_TTL_SECONDS)
+            return jwk
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+    )
+
+
+async def validate_token(token: str) -> dict[str, Any]:
+    try:
+        header = jwt.get_unverified_header(token)
+    except jwt.PyJWTError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        ) from exc
+    kid = header.get("kid")
+    if not kid:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token header"
+        )
+    jwk = await _get_jwk(kid)
+    try:
+        key = jwt.PyJWK.from_dict(jwk).key
+        payload = jwt.decode(
+            token, key, algorithms=[jwk["alg"]], options={"verify_aud": False}
+        )
+    except jwt.PyJWTError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        ) from exc
+    return payload
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+) -> dict[str, Any]:
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
+        )
+    payload = await validate_token(credentials.credentials)
+    user_id = payload.get("sub")
+    sector_id = payload.get("sector_id")
+    if user_id is None or sector_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token claims"
+        )
+    return {"user_id": user_id, "sector_id": sector_id, "claims": payload}
+
+
+__all__ = ["validate_token", "get_current_user"]

--- a/task_service/tests/test_security.py
+++ b/task_service/tests/test_security.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import asyncio
+import types
+
+import httpx
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi.security import HTTPAuthorizationCredentials
+from jwt.utils import base64url_encode
+
+from task_service.core import security
+
+
+@pytest.fixture()
+def token_and_jwk() -> tuple[str, dict[str, str]]:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = private_key.public_key()
+    numbers = public_key.public_numbers()
+    n = base64url_encode(
+        numbers.n.to_bytes((numbers.n.bit_length() + 7) // 8, "big")
+    ).decode()
+    e = base64url_encode(
+        numbers.e.to_bytes((numbers.e.bit_length() + 7) // 8, "big")
+    ).decode()
+    jwk = {"kty": "RSA", "use": "sig", "kid": "test", "alg": "RS256", "n": n, "e": e}
+    token = jwt.encode(
+        {"sub": "123", "sector_id": 5},
+        private_key,
+        algorithm="RS256",
+        headers={"kid": "test"},
+    )
+    return token, jwk
+
+
+def test_validate_token_uses_cache(monkeypatch, token_and_jwk) -> None:
+    token, jwk = token_and_jwk
+    calls = {"count": 0}
+
+    async def mock_get(self, url):  # type: ignore[override]
+        calls["count"] += 1
+
+        class Resp:
+            def raise_for_status(self) -> None:  # pragma: no cover - trivial
+                pass
+
+            def json(
+                self,
+            ) -> dict[str, list[dict[str, str]]]:  # pragma: no cover - trivial
+                return {"keys": [jwk]}
+
+        return Resp()
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", mock_get)
+    security._jwks_cache.clear()
+    asyncio.run(security.validate_token(token))
+    asyncio.run(security.validate_token(token))
+    assert calls["count"] == 1
+
+
+def test_jwk_cache_expires(monkeypatch, token_and_jwk) -> None:
+    token, jwk = token_and_jwk
+    calls = {"count": 0}
+
+    async def mock_get(self, url):  # type: ignore[override]
+        calls["count"] += 1
+
+        class Resp:
+            def raise_for_status(self) -> None:  # pragma: no cover
+                pass
+
+            def json(self) -> dict[str, list[dict[str, str]]]:  # pragma: no cover
+                return {"keys": [jwk]}
+
+        return Resp()
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", mock_get)
+    security._jwks_cache.clear()
+    monkeypatch.setattr(security, "JWKS_CACHE_TTL_SECONDS", 10)
+    current_time = 0.0
+    monkeypatch.setattr(
+        security, "time", types.SimpleNamespace(time=lambda: current_time)
+    )
+    asyncio.run(security.validate_token(token))
+    current_time = 20.0
+    asyncio.run(security.validate_token(token))
+    assert calls["count"] == 2
+
+
+def test_get_current_user(monkeypatch, token_and_jwk) -> None:
+    token, jwk = token_and_jwk
+
+    async def mock_get(self, url):  # type: ignore[override]
+        class Resp:
+            def raise_for_status(self) -> None:  # pragma: no cover
+                pass
+
+            def json(self) -> dict[str, list[dict[str, str]]]:  # pragma: no cover
+                return {"keys": [jwk]}
+
+        return Resp()
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", mock_get)
+    security._jwks_cache.clear()
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+    user = asyncio.run(security.get_current_user(creds))
+    assert user["user_id"] == "123"
+    assert user["sector_id"] == 5


### PR DESCRIPTION
## Summary
- add JWKS-based token validation with per-kid caching and TTL
- expose `get_current_user` dependency to return user info and claims
- cover token validation and caching with unit tests

## Testing
- `pre-commit run --files task_service/core/security.py task_service/tests/test_security.py`
- `pytest task_service/tests/test_security.py`
- `pytest` *(fails: AttributeError: module 'app.models' has no attribute 'Sector')*

------
https://chatgpt.com/codex/tasks/task_e_689a5b62bb7483238cb799b450be0210