### PR TITLE
feat: add project permission dependency

### DIFF
--- a/task_service/core/permissions.py
+++ b/task_service/core/permissions.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from fastapi import Depends, HTTPException, status
+
+from .security import get_current_user
+from .settings import settings
+
+# Mapping of actions to roles allowed to perform them
+ROLE_PERMISSIONS: dict[str, set[str]] = {
+    "create": {"Owner", "Manager", "Contributor"},
+    "edit": {"Owner", "Manager", "Contributor"},
+    "list": {"Owner", "Manager", "Contributor", "Viewer"},
+}
+
+
+async def _fetch_project_role(
+    project_id: int,
+    user_id: str,
+    base_url: str | None = None,
+) -> str | None:
+    """Return the role of ``user_id`` in ``project_id``.
+
+    The information is retrieved from the user service.  If the user is not a
+    member of the project the service is expected to return a 404 status code.
+    """
+    base_url = base_url or str(settings.user_service_base_url)
+    async with httpx.AsyncClient(base_url=base_url) as client:
+        resp = await client.get(f"/projects/{project_id}/members/{user_id}")
+        if resp.status_code == status.HTTP_404_NOT_FOUND:
+            return None
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("role")
+
+
+def require_project_permission(action: str):
+    """FastAPI dependency ensuring the current user has the required role.
+
+    Parameters
+    ----------
+    action:
+        The action being performed.  Must be one of ``create``, ``edit`` or
+        ``list``.
+    """
+
+    allowed_roles = ROLE_PERMISSIONS[action]
+
+    async def dependency(
+        project_id: int,
+        user: dict[str, Any] = Depends(get_current_user),
+    ) -> dict[str, Any]:
+        role = await _fetch_project_role(project_id, user["user_id"])
+        if role is None or role not in allowed_roles:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not enough permissions",
+            )
+        return {"project_id": project_id, "user_id": user["user_id"], "role": role}
+
+    return dependency
+
+
+__all__ = [
+    "ROLE_PERMISSIONS",
+    "require_project_permission",
+]

--- a/task_service/tests/test_permissions.py
+++ b/task_service/tests/test_permissions.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from task_service.core import permissions, security
+
+
+@pytest.fixture()
+def app(monkeypatch) -> FastAPI:
+    async def mock_user() -> dict[str, int | dict]:  # type: ignore[override]
+        return {"user_id": "1", "sector_id": 5, "claims": {}}
+
+    monkeypatch.setattr(security, "get_current_user", mock_user)
+    monkeypatch.setattr(permissions, "get_current_user", mock_user)
+
+    app = FastAPI()
+
+    @app.post(
+        "/projects/{project_id}/tasks",
+        dependencies=[Depends(permissions.require_project_permission("create"))],
+    )
+    async def create_task(
+        project_id: int,
+    ) -> dict[str, str]:  # pragma: no cover - trivial
+        return {"status": "created"}
+
+    @app.patch(
+        "/projects/{project_id}/tasks/{task_id}",
+        dependencies=[Depends(permissions.require_project_permission("edit"))],
+    )
+    async def edit_task(
+        project_id: int, task_id: int
+    ) -> dict[str, str]:  # pragma: no cover - trivial
+        return {"status": "edited"}
+
+    @app.get(
+        "/projects/{project_id}/tasks",
+        dependencies=[Depends(permissions.require_project_permission("list"))],
+    )
+    async def list_tasks(
+        project_id: int,
+    ) -> dict[str, str]:  # pragma: no cover - trivial
+        return {"status": "ok"}
+
+    return app
+
+
+def test_viewer_can_list(app: FastAPI, monkeypatch) -> None:
+    async def mock_fetch(
+        project_id: int, user_id: str, base_url: str | None = None
+    ) -> str | None:
+        return "Viewer"
+
+    monkeypatch.setattr(permissions, "_fetch_project_role", mock_fetch)
+    client = TestClient(app)
+    resp = client.get("/projects/1/tasks")
+    assert resp.status_code == 200
+
+
+def test_contributor_can_create(app: FastAPI, monkeypatch) -> None:
+    async def mock_fetch(
+        project_id: int, user_id: str, base_url: str | None = None
+    ) -> str | None:
+        return "Contributor"
+
+    monkeypatch.setattr(permissions, "_fetch_project_role", mock_fetch)
+    client = TestClient(app)
+    resp = client.post("/projects/1/tasks")
+    assert resp.status_code == 200
+
+
+def test_viewer_cannot_create(app: FastAPI, monkeypatch) -> None:
+    async def mock_fetch(
+        project_id: int, user_id: str, base_url: str | None = None
+    ) -> str | None:
+        return "Viewer"
+
+    monkeypatch.setattr(permissions, "_fetch_project_role", mock_fetch)
+    client = TestClient(app)
+    resp = client.post("/projects/1/tasks")
+    assert resp.status_code == 403
+
+
+def test_viewer_cannot_edit(app: FastAPI, monkeypatch) -> None:
+    async def mock_fetch(
+        project_id: int, user_id: str, base_url: str | None = None
+    ) -> str | None:
+        return "Viewer"
+
+    monkeypatch.setattr(permissions, "_fetch_project_role", mock_fetch)
+    client = TestClient(app)
+    resp = client.patch("/projects/1/tasks/1")
+    assert resp.status_code == 403
+
+
+def test_non_member_forbidden(app: FastAPI, monkeypatch) -> None:
+    async def mock_fetch(
+        project_id: int, user_id: str, base_url: str | None = None
+    ) -> str | None:
+        return None
+
+    monkeypatch.setattr(permissions, "_fetch_project_role", mock_fetch)
+    client = TestClient(app)
+    resp = client.get("/projects/1/tasks")
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- add dependency to enforce project role permissions
- validate project membership via user service
- cover permission checks with tests

## Testing
- `pre-commit run --files task_service/core/permissions.py task_service/tests/test_permissions.py`
- `pytest task_service/tests/test_permissions.py task_service/tests/test_security.py`

------
https://chatgpt.com/codex/tasks/task_e_689a5eed99288323a80fed87fe25ac7b