### PR TITLE
Add project endpoints and membership management

### DIFF
--- a/services/user-service/tests/conftest.py
+++ b/services/user-service/tests/conftest.py
@@ -23,7 +23,10 @@ def client(
     monkeypatch.setenv("SMTP_PASSWORD", "pass")
     monkeypatch.setenv("CORS_ALLOW_ORIGINS", '["*"]')
 
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    for key in list(sys.modules):
+        if key.startswith("app"):
+            sys.modules.pop(key, None)
     from app.database import Base, engine  # noqa: E402
     from app.main import app  # noqa: E402
 

--- a/task_service/api/projects.py
+++ b/task_service/api/projects.py
@@ -1,0 +1,146 @@
+"""Project API endpoints."""
+
+from __future__ import annotations
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from task_service.core.database import get_session
+from task_service.core.settings import settings
+from task_service.domain.schemas import (
+    ProjectCreate,
+    ProjectRead,
+    ProjectMemberRead,
+    ProjectMemberUpdate,
+)
+from task_service.services import ProjectService
+
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+
+def get_project_service() -> ProjectService:
+    return ProjectService()
+
+
+class ProjectUpdate(BaseModel):
+    name: str | None = None
+    slug: str | None = None
+
+
+@router.post("/", response_model=ProjectRead, status_code=status.HTTP_201_CREATED)
+async def create_project(
+    project_in: ProjectCreate,
+    session: AsyncSession = Depends(get_session),
+    service: ProjectService = Depends(get_project_service),
+) -> ProjectRead:
+    """Create a new project."""
+    project = await service.create(session, project_in)
+    return ProjectRead.model_validate(project)
+
+
+@router.get("/", response_model=dict[str, list[ProjectRead]])
+async def list_projects(
+    offset: int = 0,
+    limit: int = Query(100, ge=1),
+    session: AsyncSession = Depends(get_session),
+    service: ProjectService = Depends(get_project_service),
+) -> dict[str, list[ProjectRead]]:
+    """List projects."""
+    projects = await service.list(session, offset=offset, limit=limit)
+    data = [ProjectRead.model_validate(p) for p in projects]
+    return {"projects": data}
+
+
+@router.get("/{project_id}", response_model=ProjectRead)
+async def get_project(
+    project_id: int,
+    session: AsyncSession = Depends(get_session),
+    service: ProjectService = Depends(get_project_service),
+) -> ProjectRead:
+    """Retrieve a project by its ID."""
+    project = await service.get(session, project_id)
+    if not project:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Project not found"
+        )
+    return ProjectRead.model_validate(project)
+
+
+@router.patch("/{project_id}", response_model=ProjectRead)
+async def update_project(
+    project_id: int,
+    project_in: ProjectUpdate,
+    session: AsyncSession = Depends(get_session),
+    service: ProjectService = Depends(get_project_service),
+) -> ProjectRead:
+    """Partially update a project."""
+    data = project_in.model_dump(exclude_unset=True)
+    project = await service.update(session, project_id, data)
+    if not project:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Project not found"
+        )
+    return ProjectRead.model_validate(project)
+
+
+@router.get("/{project_id}/members", response_model=dict[str, list[ProjectMemberRead]])
+async def list_members(project_id: int) -> dict[str, list[ProjectMemberRead]]:
+    """List members of a project.
+
+    This endpoint proxies the request to the user service.
+    """
+    async with httpx.AsyncClient(base_url=str(settings.user_service_base_url)) as client:
+        resp = await client.get(f"/projects/{project_id}/members")
+    if resp.status_code == status.HTTP_404_NOT_FOUND:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Project not found"
+        )
+    resp.raise_for_status()
+    data = resp.json()
+    members = data.get("members", data)
+    return {"members": [ProjectMemberRead.model_validate(m) for m in members]}
+
+
+@router.put(
+    "/{project_id}/members/{user_id}",
+    response_model=ProjectMemberRead,
+    status_code=status.HTTP_200_OK,
+)
+async def put_member(
+    project_id: int,
+    user_id: int,
+    member_in: ProjectMemberUpdate,
+) -> ProjectMemberRead:
+    """Add or update a project member by delegating to the user service."""
+    async with httpx.AsyncClient(base_url=str(settings.user_service_base_url)) as client:
+        resp = await client.put(
+            f"/projects/{project_id}/members/{user_id}",
+            json=member_in.model_dump(),
+        )
+    if resp.status_code == status.HTTP_404_NOT_FOUND:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Member not found"
+        )
+    resp.raise_for_status()
+    return ProjectMemberRead.model_validate(resp.json())
+
+
+@router.delete(
+    "/{project_id}/members/{user_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def delete_member(project_id: int, user_id: int) -> Response:
+    """Remove a project member via the user service."""
+    async with httpx.AsyncClient(base_url=str(settings.user_service_base_url)) as client:
+        resp = await client.delete(f"/projects/{project_id}/members/{user_id}")
+    if resp.status_code == status.HTTP_404_NOT_FOUND:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Member not found"
+        )
+    resp.raise_for_status()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+__all__ = ["router"]

--- a/task_service/api/router.py
+++ b/task_service/api/router.py
@@ -1,6 +1,10 @@
 from fastapi import APIRouter
 
+from .projects import router as projects_router
+
+
 router = APIRouter()
+router.include_router(projects_router)
 
 
 @router.get("/", summary="List tasks")

--- a/task_service/domain/schemas.py
+++ b/task_service/domain/schemas.py
@@ -48,6 +48,14 @@ class ProjectRead(ProjectBase):
     model_config = ConfigDict(from_attributes=True)
 
 
+class ProjectMemberUpdate(BaseModel):
+    role: Role
+
+
+class ProjectMemberRead(ProjectMemberUpdate):
+    user_id: int
+
+
 class ListBase(BaseModel):
     project_id: int
     name: str


### PR DESCRIPTION
## Summary
- add CRUD routes for projects
- proxy project membership operations to user service
- expose project router and adjust tests to use correct user-service package

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a637481e08323ae47c58364772f22