### PR TITLE
feat: add list endpoints and position sorting

### DIFF
--- a/task_service/api/lists.py
+++ b/task_service/api/lists.py
@@ -1,0 +1,83 @@
+"""List API endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from task_service.core.database import get_session
+from task_service.domain.schemas import ListCreate, ListRead
+from task_service.services import ListService
+
+router = APIRouter(tags=["lists"])
+
+
+def get_list_service() -> ListService:
+    return ListService()
+
+
+class ListCreateBody(BaseModel):
+    name: str
+    position: int | None = None
+
+
+class ListUpdate(BaseModel):
+    name: str | None = None
+    position: int | None = None
+
+
+@router.post(
+    "/projects/{project_id}/lists",
+    response_model=ListRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_list(
+    project_id: int,
+    list_in: ListCreateBody,
+    session: AsyncSession = Depends(get_session),
+    service: ListService = Depends(get_list_service),
+) -> ListRead:
+    """Create a new list within a project."""
+    list_data = list_in.model_dump()
+    lst = await service.create(session, ListCreate(project_id=project_id, **list_data))
+    return ListRead.model_validate(lst)
+
+
+@router.get(
+    "/projects/{project_id}/lists",
+    response_model=dict[str, list[ListRead]],
+)
+async def list_lists(
+    project_id: int,
+    offset: int = 0,
+    limit: int = Query(100, ge=1),
+    session: AsyncSession = Depends(get_session),
+    service: ListService = Depends(get_list_service),
+) -> dict[str, list[ListRead]]:
+    """List lists for a project."""
+    lists = await service.list_by_project(
+        session, project_id, offset=offset, limit=limit
+    )
+    data = [ListRead.model_validate(lst) for lst in lists]
+    return {"lists": data}
+
+
+@router.patch("/lists/{list_id}", response_model=ListRead)
+async def update_list(
+    list_id: int,
+    list_in: ListUpdate,
+    session: AsyncSession = Depends(get_session),
+    service: ListService = Depends(get_list_service),
+) -> ListRead:
+    """Partially update a list."""
+    data = list_in.model_dump(exclude_unset=True)
+    lst = await service.update(session, list_id, data)
+    if not lst:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="List not found"
+        )
+    return ListRead.model_validate(lst)
+
+
+__all__ = ["router"]

--- a/task_service/api/router.py
+++ b/task_service/api/router.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter
 
+from .lists import router as lists_router
 from .projects import router as projects_router
-
 
 router = APIRouter()
 router.include_router(projects_router)
+router.include_router(lists_router)
 
 
 @router.get("/", summary="List tasks")

--- a/task_service/domain/models.py
+++ b/task_service/domain/models.py
@@ -73,7 +73,7 @@ class List(Base):
         Integer, ForeignKey("projects.id", ondelete="CASCADE"), nullable=False
     )
     name: Mapped[str] = mapped_column(String, nullable=False)
-    order: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    position: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow

--- a/task_service/domain/schemas.py
+++ b/task_service/domain/schemas.py
@@ -59,7 +59,7 @@ class ProjectMemberRead(ProjectMemberUpdate):
 class ListBase(BaseModel):
     project_id: int
     name: str
-    order: int | None = None
+    position: int | None = None
 
 
 class ListCreate(ListBase):

--- a/task_service/repositories/lists.py
+++ b/task_service/repositories/lists.py
@@ -31,7 +31,7 @@ class ListRepository:
         stmt: Select[tuple[List]] = (
             select(List)
             .where(List.project_id == project_id)
-            .order_by(List.order)
+            .order_by(List.position)
             .offset(offset)
             .limit(limit)
         )


### PR DESCRIPTION
## Summary
- add CRUD endpoints for project lists
- order lists by position instead of order

## Testing
- `pre-commit run --files task_service/api/router.py task_service/domain/models.py task_service/domain/schemas.py task_service/repositories/lists.py task_service/api/lists.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a823b7d6483239a1456e656358bc8