### PR TITLE
feat: add task comment API with mention parsing

### DIFF
--- a/task_service/api/comments.py
+++ b/task_service/api/comments.py
@@ -1,0 +1,69 @@
+"""Comment API endpoints."""
+
+from __future__ import annotations
+
+import re
+
+from fastapi import APIRouter, Depends, Query, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from task_service.core.database import get_session
+from task_service.domain.schemas import CommentCreate, CommentRead
+from task_service.services import CommentService
+
+router = APIRouter(tags=["comments"])
+
+
+def get_comment_service() -> CommentService:
+    return CommentService()
+
+
+class CommentCreateBody(BaseModel):
+    content: str
+    author_id: int | None = None
+
+
+def parse_mentions(text: str) -> list[str]:
+    """Extract ``@user`` mentions from ``text``."""
+
+    return re.findall(r"@([A-Za-z0-9_]+)", text)
+
+
+@router.post(
+    "/tasks/{task_id}/comments",
+    response_model=CommentRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_comment(
+    task_id: int,
+    comment_in: CommentCreateBody,
+    session: AsyncSession = Depends(get_session),
+    service: CommentService = Depends(get_comment_service),
+) -> CommentRead:
+    data = comment_in.model_dump()
+    comment = await service.create(session, CommentCreate(task_id=task_id, **data))
+    base = CommentRead.model_validate(comment)
+    return base.model_copy(update={"mentions": parse_mentions(base.content)})
+
+
+@router.get(
+    "/tasks/{task_id}/comments",
+    response_model=dict[str, list[CommentRead]],
+)
+async def list_comments(
+    task_id: int,
+    offset: int = 0,
+    limit: int = Query(100, ge=1),
+    session: AsyncSession = Depends(get_session),
+    service: CommentService = Depends(get_comment_service),
+) -> dict[str, list[CommentRead]]:
+    comments = await service.list_by_task(session, task_id, offset=offset, limit=limit)
+    data: list[CommentRead] = []
+    for comment in comments:
+        base = CommentRead.model_validate(comment)
+        data.append(base.model_copy(update={"mentions": parse_mentions(base.content)}))
+    return {"comments": data}
+
+
+__all__ = ["router"]

--- a/task_service/api/router.py
+++ b/task_service/api/router.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from .comments import router as comments_router
 from .lists import router as lists_router
 from .projects import router as projects_router
 from .tasks import router as tasks_router
@@ -8,3 +9,4 @@ router = APIRouter()
 router.include_router(projects_router)
 router.include_router(lists_router)
 router.include_router(tasks_router)
+router.include_router(comments_router)

--- a/task_service/domain/schemas.py
+++ b/task_service/domain/schemas.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class Status(str, Enum):
@@ -136,6 +136,7 @@ class CommentRead(CommentBase):
     author_id: int | None = None
     created_at: datetime
     updated_at: datetime
+    mentions: list[str] = Field(default_factory=list)
 
     model_config = ConfigDict(from_attributes=True)
 


### PR DESCRIPTION
## Summary
- add API endpoints to list and create task comments
- parse optional @user mentions in comment content
- expose comments router and schema mentions field

## Testing
- `pre-commit run --files task_service/domain/schemas.py task_service/api/comments.py task_service/api/router.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689aa10af868832386cb560cbcdebaca