### PR TITLE
feat: add health and metrics endpoints

### DIFF
--- a/task_service/api/health.py
+++ b/task_service/api/health.py
@@ -1,0 +1,36 @@
+"""Health and metrics endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from task_service.core.database import get_session
+from task_service.core.metrics import TASKS_STATUS_GAUGE
+from task_service.services import TaskService
+
+router = APIRouter()
+
+
+def get_task_service() -> TaskService:
+    return TaskService()
+
+
+@router.get("/healthz")
+async def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@router.get("/metrics")
+async def metrics(
+    session: AsyncSession = Depends(get_session),
+    service: TaskService = Depends(get_task_service),
+) -> Response:
+    counts = await service.count_by_status(session)
+    for status, count in counts.items():
+        TASKS_STATUS_GAUGE.labels(status=status).set(count)
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+__all__ = ["router"]

--- a/task_service/core/metrics.py
+++ b/task_service/core/metrics.py
@@ -1,0 +1,29 @@
+"""Prometheus metric definitions."""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Gauge, Histogram
+
+REQUEST_COUNTER = Counter(
+    "http_requests_total",
+    "Total HTTP requests",
+    ["method", "path", "status_code"],
+)
+
+REQUEST_LATENCY = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request duration in seconds",
+    ["method", "path"],
+)
+
+TASKS_STATUS_GAUGE = Gauge(
+    "tasks_status_total",
+    "Number of tasks by status",
+    ["status"],
+)
+
+__all__ = [
+    "REQUEST_COUNTER",
+    "REQUEST_LATENCY",
+    "TASKS_STATUS_GAUGE",
+]

--- a/task_service/core/middleware.py
+++ b/task_service/core/middleware.py
@@ -1,8 +1,11 @@
+import time
 import uuid
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
+
+from task_service.core.metrics import REQUEST_COUNTER, REQUEST_LATENCY
 
 
 class RequestIDMiddleware(BaseHTTPMiddleware):
@@ -13,4 +16,22 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
         request.state.request_id = request_id
         response = await call_next(request)
         response.headers["X-Request-ID"] = request_id
+        return response
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Middleware collecting Prometheus metrics for each request."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        start = time.perf_counter()
+        response = await call_next(request)
+        elapsed = time.perf_counter() - start
+        route = request.scope.get("route")
+        path = route.path if route else request.url.path
+        REQUEST_COUNTER.labels(
+            method=request.method,
+            path=path,
+            status_code=response.status_code,
+        ).inc()
+        REQUEST_LATENCY.labels(method=request.method, path=path).observe(elapsed)
         return response

--- a/task_service/main.py
+++ b/task_service/main.py
@@ -1,15 +1,17 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from task_service.api.health import router as health_router
 from task_service.api.router import router
 from task_service.core.logging import configure_logging
-from task_service.core.middleware import RequestIDMiddleware
+from task_service.core.middleware import MetricsMiddleware, RequestIDMiddleware
 
 configure_logging()
 
 app = FastAPI(title="Task Service")
 
 app.add_middleware(RequestIDMiddleware)
+app.add_middleware(MetricsMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
@@ -21,4 +23,5 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+app.include_router(health_router)
 app.include_router(router, prefix="/tasks")

--- a/task_service/tests/test_health_metrics.py
+++ b/task_service/tests/test_health_metrics.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+# ruff: noqa: E402
+
+
+os.environ["TASKS_DATABASE_URL"] = "sqlite+aiosqlite://"
+
+from task_service.core.database import get_session
+from task_service.main import app
+from task_service.services import TaskService
+
+
+@pytest.fixture(autouse=True)
+def override_session() -> None:
+    async def _override_session():
+        class Dummy:  # pragma: no cover - placeholder
+            pass
+
+        yield Dummy()
+
+    app.dependency_overrides[get_session] = _override_session
+    yield
+    app.dependency_overrides.clear()
+
+
+def test_healthz() -> None:
+    client = TestClient(app)
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_count_by_status(
+        self, session, project_id=None  # type: ignore[override]
+    ) -> dict[str, int]:
+        return {"pending": 1}
+
+    monkeypatch.setattr(TaskService, "count_by_status", fake_count_by_status)
+    client = TestClient(app)
+    client.get("/healthz")
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "http_requests_total" in body
+    assert 'path="/healthz"' in body
+    assert 'tasks_status_total{status="pending"} 1.0' in body


### PR DESCRIPTION
## Summary
- add /healthz and /metrics endpoints
- instrument requests with Prometheus metrics
- count tasks by status in metrics

## Testing
- `pre-commit run --files task_service/core/middleware.py task_service/main.py task_service/api/health.py task_service/core/metrics.py task_service/tests/test_health_metrics.py`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689aa31f54d0832380a4b58c161f2594