### PR TITLE
Add pagination envelope and standardized error schema

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+profile=black
+line_length=88

--- a/task_service/domain/schemas.py
+++ b/task_service/domain/schemas.py
@@ -122,6 +122,22 @@ class TaskRead(TaskBase):
     model_config = ConfigDict(from_attributes=True)
 
 
+class Pagination(BaseModel):
+    total: int
+    offset: int
+    limit: int
+
+
+class TaskListResponse(BaseModel):
+    tasks: list[TaskRead]
+    pagination: Pagination
+
+
+class ErrorResponse(BaseModel):
+    code: str
+    message: str
+
+
 class CommentBase(BaseModel):
     task_id: int
     content: str

--- a/task_service/repositories/tasks.py
+++ b/task_service/repositories/tasks.py
@@ -36,7 +36,7 @@ class TaskRepository:
         order_by: Optional[str] = None,
         order: str = "asc",
         offset: int = 0,
-        limit: int = 100,
+        limit: int | None = 100,
     ) -> list[Task]:
         stmt: Select[tuple[Task]] = select(Task)
         if project_id is not None:
@@ -62,7 +62,9 @@ class TaskRepository:
             stmt = stmt.order_by(
                 column.asc() if order.lower() == "asc" else column.desc()
             )
-        stmt = stmt.offset(offset).limit(limit)
+        stmt = stmt.offset(offset)
+        if limit is not None:
+            stmt = stmt.limit(limit)
         result = await session.execute(stmt)
         return result.scalars().all()
 

--- a/task_service/services/tasks.py
+++ b/task_service/services/tasks.py
@@ -56,7 +56,7 @@ class TaskService:
         order: str = "asc",
         offset: int = 0,
         limit: int = 100,
-    ) -> list[TaskRead]:
+    ) -> tuple[list[TaskRead], int]:
         tasks = await self.repository.list(
             session,
             project_id=project_id,
@@ -70,8 +70,8 @@ class TaskService:
             search=search,
             order_by=None if order_by == "timeliness" else order_by,
             order=order,
-            offset=offset,
-            limit=limit,
+            offset=0,
+            limit=None,
         )
         data = [self._to_read_model(task) for task in tasks]
         if timeliness is not None:
@@ -82,7 +82,9 @@ class TaskService:
                 key=lambda t: order_map.get(t.timeliness, 3),
                 reverse=order.lower() == "desc",
             )
-        return data
+        total = len(data)
+        data = data[offset : offset + limit]
+        return data, total
 
     async def move(
         self, session: AsyncSession, task_id: int, *, list_id: int

--- a/task_service/tests/test_api_tasks.py
+++ b/task_service/tests/test_api_tasks.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+os.environ["TASKS_DATABASE_URL"] = "sqlite+aiosqlite://"
+
+from task_service.api.tasks import get_task_service  # noqa: E402
+from task_service.core.database import Base, get_session  # noqa: E402
+from task_service.domain.schemas import (  # noqa: E402
+    ErrorResponse,
+    ProjectCreate,
+    TaskCreate,
+    TaskListResponse,
+)
+from task_service.main import app  # noqa: E402
+from task_service.repositories import ProjectRepository  # noqa: E402
+from task_service.services.tasks import TaskService  # noqa: E402
+
+
+class DummyUserClient:
+    async def verify_users(self, user_ids):  # pragma: no cover - simple stub
+        return None
+
+    async def get_sector_name(self, sector_id):  # pragma: no cover - simple stub
+        return "Sector"
+
+
+@pytest_asyncio.fixture()
+async def client() -> AsyncIterator[tuple[AsyncClient, AsyncSession]]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql("ATTACH DATABASE ':memory:' AS tasks")
+        await conn.run_sync(Base.metadata.create_all)
+    async_session = async_sessionmaker(engine, expire_on_commit=False)
+    async with async_session() as session:
+
+        async def override_get_session() -> AsyncIterator[AsyncSession]:
+            yield session
+
+        app.dependency_overrides[get_session] = override_get_session
+        app.dependency_overrides[get_task_service] = lambda: TaskService(
+            user_client=DummyUserClient()
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac, session
+        app.dependency_overrides.clear()
+    await engine.dispose()
+
+
+@pytest.mark.asyncio()
+async def test_list_tasks_pagination(client: tuple[AsyncClient, AsyncSession]) -> None:
+    ac, session = client
+    project_repo = ProjectRepository()
+    project = await project_repo.create(session, ProjectCreate(name="p", slug="p"))
+    service = TaskService(user_client=DummyUserClient())
+    await service.create(session, TaskCreate(project_id=project.id, title="t1"))
+    await service.create(session, TaskCreate(project_id=project.id, title="t2"))
+    resp = await ac.get(f"/tasks/projects/{project.id}/tasks?offset=0&limit=1")
+    assert resp.status_code == 200
+    body = TaskListResponse.model_validate(resp.json())
+    assert body.pagination.total == 2
+    assert len(body.tasks) == 1
+
+
+@pytest.mark.asyncio()
+async def test_get_task_not_found(client: tuple[AsyncClient, AsyncSession]) -> None:
+    ac, _ = client
+    resp = await ac.get("/tasks/tasks/999")
+    assert resp.status_code == 404
+    error = ErrorResponse.model_validate(resp.json()["detail"])
+    assert error.code == "TASK_NOT_FOUND"


### PR DESCRIPTION
## Summary
- add Pagination, TaskListResponse and ErrorResponse schemas
- support total-based pagination and standardized error codes
- validate responses with new API tests using Pydantic

## Testing
- `pre-commit run --files task_service/domain/schemas.py task_service/repositories/tasks.py task_service/services/tasks.py task_service/api/tasks.py task_service/tests/test_api_tasks.py .isort.cfg`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b2094333883238852f5f3659e0346