### PR TITLE
chore(task-service): use async sqlite driver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 JWT_SECRET_KEY=change-me
 JWT_ALGORITHM=HS256
 DATABASE_URL=postgresql://app:app@localhost:5432/app
+TASKS_DATABASE_URL=sqlite+aiosqlite:///./tasks.db
 SMTP_HOST=localhost
 SMTP_PORT=1025
 SMTP_USER=user

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Crie um arquivo `.env` local baseado em `.env.example`:
 cp .env.example .env
 ```
 
-Este arquivo **não deve** ser versionado. Em pipelines de CI/CD, defina as mesmas
+Este arquivo inclui, entre outras variáveis, `TASKS_DATABASE_URL`, que deve usar
+um driver assíncrono (por padrão `sqlite+aiosqlite:///./tasks.db`).
+O arquivo **não deve** ser versionado. Em pipelines de CI/CD, defina as mesmas
 variáveis diretamente no ambiente de execução ou utilize mecanismos seguros como
 Docker secrets e configurações da plataforma escolhida.
 

--- a/services/task-service/app/core/settings.py
+++ b/services/task-service/app/core/settings.py
@@ -9,7 +9,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     tasks_database_url: AnyUrl = Field(
-        "sqlite:///./tasks.db", alias="TASKS_DATABASE_URL"
+        "sqlite+aiosqlite:///./tasks.db", alias="TASKS_DATABASE_URL"
     )
     auth_jwks_url: AnyHttpUrl = Field(
         "http://auth-service/jwks.json", alias="AUTH_JWKS_URL"


### PR DESCRIPTION
## Summary
- switch task service default DB to `sqlite+aiosqlite`
- document async DB URL and add sample env var

## Testing
- `pre-commit run --files services/task-service/app/core/settings.py README.md .env.example`
- `pytest services/task-service/tests`


------
https://chatgpt.com/codex/tasks/task_e_689b42487f408323840377b0a0d6b9be