### PR TITLE
chore: add aiosqlite dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Este repositório utiliza ferramentas de qualidade para garantir padrões consis
 
 ## Configuração do ambiente
 
-Instale as dependências de desenvolvimento e os hooks do pre-commit:
+Instale as dependências do projeto (incluindo `aiosqlite`) e os hooks do pre-commit:
 
 ```bash
-pip install pre-commit mypy pytest pytest-cov
+pip install -r requirements.txt
 pre-commit install
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi
 uvicorn
 sqlalchemy
 alembic
+aiosqlite
 pydantic
 redis
 passlib[bcrypt]

--- a/services/auth-service/Dockerfile
+++ b/services/auth-service/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.12-slim
 WORKDIR /app
 
 COPY requirements.txt .
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install -y curl sqlite3 && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir -r requirements.txt
 
 COPY services/auth-service /app

--- a/services/task-service/Dockerfile
+++ b/services/task-service/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.12-slim
 WORKDIR /app
 
 COPY requirements.txt .
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install -y curl sqlite3 && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir -r requirements.txt
 
 COPY services/task-service /app

--- a/services/user-service/Dockerfile
+++ b/services/user-service/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.12-slim
 WORKDIR /app
 
 COPY requirements.txt .
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install -y curl sqlite3 && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir -r requirements.txt
 
 COPY services/user-service /app


### PR DESCRIPTION
## Summary
- add aiosqlite to requirements
- install sqlite3 in service Docker images
- document project dependency setup

## Testing
- `pre-commit run --files README.md requirements.txt services/auth-service/Dockerfile services/task-service/Dockerfile services/user-service/Dockerfile`
- `make typecheck` *(fails: There are no .py[i] files in directory '.')*
- `pytest` *(fails: ImportError: cannot import name 'security' from 'app')*


------
https://chatgpt.com/codex/tasks/task_e_689b4640a00883238e26c5f1efe57958