### PR TITLE
Replace aiosqlite with asyncpg dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi
 uvicorn
 sqlalchemy
 alembic
-aiosqlite
+asyncpg
 pydantic
 redis
 passlib[bcrypt]


### PR DESCRIPTION
## Summary
- switch database driver from aiosqlite to asyncpg

## Testing
- `pip install -r requirements.txt`
- `pre-commit run --files requirements.txt -v`
- `pytest -q` *(fails: ImportError: cannot import name 'security' from 'app')*

------
https://chatgpt.com/codex/tasks/task_e_689b540e7bfc83239a4308a49227baee