### PR TITLE
Add database URLs for microservices

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -46,6 +46,8 @@ services:
     build:
       context: .
       dockerfile: services/auth-service/Dockerfile
+    environment:
+      DATABASE_URL: "postgresql+asyncpg://app:app@postgres/app?options=-csearch_path%3Dauth"
     networks:
       - internal
       - traefik
@@ -76,6 +78,8 @@ services:
     build:
       context: .
       dockerfile: services/user-service/Dockerfile
+    environment:
+      DATABASE_URL: "postgresql+asyncpg://app:app@postgres/app?options=-csearch_path%3Dusers"
     networks:
       - internal
       - traefik
@@ -98,6 +102,8 @@ services:
     build:
       context: .
       dockerfile: services/task-service/Dockerfile
+    environment:
+      TASKS_DATABASE_URL: "postgresql+asyncpg://app:app@postgres/app?options=-csearch_path%3Dtasks"
     networks:
       - internal
       - traefik


### PR DESCRIPTION
## Summary
- configure auth-service, user-service, and task-service with DATABASE_URL/TASKS_DATABASE_URL using PostgreSQL schemas

## Testing
- `pre-commit run --files compose.yml`
- `pytest` *(fails: ImportError: cannot import name 'security' from 'app')*

------
https://chatgpt.com/codex/tasks/task_e_689b7096e8088323ba0b39a20c43a389