### PR TITLE
Use async SQLAlchemy session for auth service

### DIFF
--- a/services/auth-service/app/database.py
+++ b/services/auth-service/app/database.py
@@ -1,27 +1,31 @@
 from __future__ import annotations
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import DeclarativeBase, sessionmaker
+from collections.abc import AsyncGenerator
+
+from sqlalchemy import MetaData
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase
 
 from .settings import get_settings
+
+
+metadata = MetaData(schema="auth")
 
 
 class Base(DeclarativeBase):
     """Base class for all SQLAlchemy models."""
 
+    metadata = metadata
+
 
 settings = get_settings()
 
-engine = create_engine(
-    str(settings.database_url),
-    connect_args={"check_same_thread": False} if str(settings.database_url).startswith("sqlite") else {},
+engine = create_async_engine(str(settings.database_url))
+async_session_factory = async_sessionmaker(
+    engine, expire_on_commit=False, class_=AsyncSession
 )
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    async with async_session_factory() as session:
+        yield session


### PR DESCRIPTION
## Summary
- refactor auth-service database layer to use async SQLAlchemy engine and sessions

## Testing
- `PYTHONPATH=services/auth-service pytest services/auth-service/tests/test_auth.py::test_register_login_me_flow -q` *(fails: The asyncio extension requires an async driver to be used. The loaded 'pysqlite' is not async.)*

------
https://chatgpt.com/codex/tasks/task_e_689ccf41f5b88323a025f33f96c4675a