### PR TITLE
refactor: migrate auth service to async SQLAlchemy

### DIFF
--- a/services/auth-service/app/audit.py
+++ b/services/auth-service/app/audit.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from typing import Optional
 from uuid import UUID
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from .models import AuditLog
 
 
-def log_event(
-    db: Session,
+async def log_event(
+    db: AsyncSession,
     action: str,
     user_id: Optional[UUID] = None,
     ip: str | None = None,
@@ -17,4 +17,4 @@ def log_event(
 ) -> None:
     entry = AuditLog(user_id=user_id, action=action, ip_address=ip, user_agent=user_agent)
     db.add(entry)
-    db.commit()
+    await db.commit()

--- a/services/auth-service/app/database.py
+++ b/services/auth-service/app/database.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 
-from sqlalchemy import MetaData
+from sqlalchemy import MetaData, create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
 
@@ -20,10 +20,20 @@ class Base(DeclarativeBase):
 
 settings = get_settings()
 
-engine = create_async_engine(str(settings.database_url))
+database_url = str(settings.database_url)
+if database_url.startswith("sqlite://") and not database_url.startswith("sqlite+aiosqlite://"):
+    database_url = database_url.replace("sqlite://", "sqlite+aiosqlite://", 1)
+if database_url.startswith("sqlite+aiosqlite://"):
+    metadata.schema = None
+
+async_engine = create_async_engine(database_url)
 async_session_factory = async_sessionmaker(
-    engine, expire_on_commit=False, class_=AsyncSession
+    async_engine, expire_on_commit=False, class_=AsyncSession
 )
+
+# Expose a synchronous engine for compatibility with tests
+sync_database_url = database_url.replace("sqlite+aiosqlite://", "sqlite://", 1)
+engine = create_engine(sync_database_url)
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:


### PR DESCRIPTION
## Summary
- convert auth API and audit logging to async/await
- switch to AsyncSession and async SQLAlchemy engine

## Testing
- `pytest services/auth-service/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689cdd06d6508323897df1ce309f4c5a