### PR TITLE
Use async startup and configure Alembic

### DIFF
--- a/services/auth-service/alembic.ini
+++ b/services/auth-service/alembic.ini
@@ -1,3 +1,3 @@
 [alembic]
 script_location = alembic
-sqlalchemy.url = sqlite:///./app.db
+sqlalchemy.url = ${DATABASE_URL}

--- a/services/auth-service/alembic/env.py
+++ b/services/auth-service/alembic/env.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
 
+import os
 import sys
-from pathlib import Path
 from logging.config import fileConfig
+from pathlib import Path
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import engine_from_config, pool, text
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "app"))
 
-from app.database import Base  # noqa: E402
 from app import models  # noqa: E402,F401
+from app.database import Base  # noqa: E402
 
 config = context.config
+database_url = os.getenv("DATABASE_URL")
+if database_url:
+    config.set_main_option("sqlalchemy.url", database_url)
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
@@ -22,7 +26,12 @@ target_metadata = Base.metadata
 
 def run_migrations_offline() -> None:
     url = config.get_main_option("sqlalchemy.url")
-    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        version_table_schema="auth",
+    )
     with context.begin_transaction():
         context.run_migrations()
 
@@ -34,7 +43,12 @@ def run_migrations_online() -> None:
         poolclass=pool.NullPool,
     )
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+        connection.execute(text("SET search_path TO auth"))
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            version_table_schema="auth",
+        )
         with context.begin_transaction():
             context.run_migrations()
 


### PR DESCRIPTION
## Summary
- make auth service startup event async and create tables with async engine
- load database url for alembic and run migrations in auth schema

## Testing
- `pre-commit run --files services/auth-service/app/main.py services/auth-service/alembic.ini services/auth-service/alembic/env.py`
- `pytest services/auth-service/tests`


------
https://chatgpt.com/codex/tasks/task_e_689cded1bfa08323a3084d992aacfe57