### PR TITLE
refactor: migrate user-service to async sqlalchemy

### DIFF
--- a/services/user-service/app/database.py
+++ b/services/user-service/app/database.py
@@ -1,31 +1,43 @@
 from __future__ import annotations
 
-from sqlalchemy import create_engine
+from collections.abc import AsyncGenerator
+
+from sqlalchemy import MetaData, create_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
 from .settings import get_settings
+
+metadata = MetaData(schema="users")
 
 
 class Base(DeclarativeBase):
     """Base class for all SQLAlchemy models."""
 
+    metadata = metadata
+
 
 settings = get_settings()
 
-engine = create_engine(
-    str(settings.database_url),
-    connect_args=(
-        {"check_same_thread": False}
-        if str(settings.database_url).startswith("sqlite")
-        else {}
-    ),
+database_url = str(settings.database_url)
+if database_url.startswith("sqlite://") and not database_url.startswith(
+    "sqlite+aiosqlite://"
+):
+    database_url = database_url.replace("sqlite://", "sqlite+aiosqlite://", 1)
+if database_url.startswith("sqlite+aiosqlite://"):
+    metadata.schema = None
+
+async_engine = create_async_engine(database_url)
+async_session_factory = async_sessionmaker(
+    async_engine, expire_on_commit=False, class_=AsyncSession
 )
+
+# Expose a synchronous engine and session factory for compatibility with tests
+sync_database_url = database_url.replace("sqlite+aiosqlite://", "sqlite://", 1)
+engine = create_engine(sync_database_url)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    async with async_session_factory() as session:
+        yield session

--- a/services/user-service/app/seed.py
+++ b/services/user-service/app/seed.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from . import models
 
 
-def seed_initial_data(db: Session) -> None:
+async def seed_initial_data(db: AsyncSession) -> None:
     # Seed roles
-    if not db.query(models.Role).first():
+    roles_exist = (await db.execute(select(models.Role))).scalars().first()
+    if not roles_exist:
         db.add_all(
             [
                 models.Role(name="admin"),
@@ -15,21 +17,34 @@ def seed_initial_data(db: Session) -> None:
                 models.Role(name="user"),
             ]
         )
-        db.commit()
+        await db.commit()
     # Seed sectors
-    if not db.query(models.Sector).first():
+    sectors_exist = (await db.execute(select(models.Sector))).scalars().first()
+    if not sectors_exist:
         gerente = models.Sector(name="Gerente")
         db.add(gerente)
-        db.commit()
+        await db.commit()
     # Seed admin user
-    admin = db.query(models.User).filter_by(email="admin@example.com").first()
+    admin = (
+        (await db.execute(select(models.User).filter_by(email="admin@example.com")))
+        .scalars()
+        .first()
+    )
     if not admin:
         admin = models.User(email="admin@example.com", full_name="Admin")
-        admin_role = db.query(models.Role).filter_by(name="admin").first()
-        gerente_sector = db.query(models.Sector).filter_by(name="Gerente").first()
+        admin_role = (
+            (await db.execute(select(models.Role).filter_by(name="admin")))
+            .scalars()
+            .first()
+        )
+        gerente_sector = (
+            (await db.execute(select(models.Sector).filter_by(name="Gerente")))
+            .scalars()
+            .first()
+        )
         if admin_role:
             admin.roles.append(admin_role)
         if gerente_sector:
             admin.sectors.append(gerente_sector)
         db.add(admin)
-        db.commit()
+        await db.commit()


### PR DESCRIPTION
## Summary
- use SQLAlchemy async engine and session for user-service
- expose async database dependency and update API
- run database seeding and startup with async sessions

## Testing
- `python -m pytest services/user-service/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf2dea26c83239a180808c10fe07f