### PR TITLE
feat: async user service startup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ cryptography
 fakeredis
 pytest
 pytest-cov
+pytest-asyncio
 httpx
 pydantic-settings
 prometheus-client

--- a/services/user-service/Dockerfile
+++ b/services/user-service/Dockerfile
@@ -4,8 +4,11 @@ FROM python:3.12-slim
 WORKDIR /app
 
 COPY requirements.txt .
-RUN apt-get update && apt-get install -y curl sqlite3 && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir -r requirements.txt
+RUN apt-get update \
+    && apt-get install -y curl build-essential libpq-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r requirements.txt \
+    && pip install --no-cache-dir asyncpg
 
 COPY services/user-service /app
 

--- a/services/user-service/alembic.ini
+++ b/services/user-service/alembic.ini
@@ -1,3 +1,4 @@
 [alembic]
 script_location = alembic
-sqlalchemy.url = sqlite:///./app.db
+sqlalchemy.url = postgresql+asyncpg://postgres:postgres@postgres/postgres
+version_table_schema = users

--- a/services/user-service/alembic/env.py
+++ b/services/user-service/alembic/env.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
+import asyncio
 import sys
 from logging.config import fileConfig
 from pathlib import Path
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import pool
+from sqlalchemy.ext.asyncio import async_engine_from_config
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "app"))
 
-from app import models  # noqa: E402,F401
+from app import models  # noqa: F401  # ensure models are imported
 from app.database import Base  # noqa: E402
 
 config = context.config
@@ -18,28 +20,45 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 target_metadata = Base.metadata
+schema = config.get_main_option("version_table_schema", "users")
 
 
 def run_migrations_offline() -> None:
     url = config.get_main_option("sqlalchemy.url")
-    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        include_schemas=True,
+        version_table_schema=schema,
+    )
     with context.begin_transaction():
         context.run_migrations()
 
 
-def run_migrations_online() -> None:
-    connectable = engine_from_config(
+def do_run_migrations(connection) -> None:
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        include_schemas=True,
+        version_table_schema=schema,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
+    connectable = async_engine_from_config(
         config.get_section(config.config_ini_section),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )
-    with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
-        with context.begin_transaction():
-            context.run_migrations()
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
 
 
 if context.is_offline_mode():
     run_migrations_offline()
 else:
-    run_migrations_online()
+    asyncio.run(run_migrations_online())

--- a/services/user-service/app/main.py
+++ b/services/user-service/app/main.py
@@ -81,7 +81,7 @@ async def on_startup() -> None:  # pragma: no cover - database side effects
     async with async_engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     # Seed initial data
-    async with async_session_factory() as db:
+    async with async_session_factory() as db:  # type: AsyncSession
         await seed_initial_data(db)
 
 

--- a/services/user-service/app/models.py
+++ b/services/user-service/app/models.py
@@ -53,12 +53,12 @@ class User(Base):
 
     roles: Mapped[list["Role"]] = relationship(
         "Role",
-        secondary="user_roles",
+        secondary=UserRole.__table__,
         back_populates="users",
     )
     sectors: Mapped[list["Sector"]] = relationship(
         "Sector",
-        secondary="user_sectors",
+        secondary=UserSector.__table__,
         back_populates="users",
     )
 
@@ -72,7 +72,7 @@ class Role(Base):
     name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
 
     users: Mapped[list[User]] = relationship(
-        "User", secondary="user_roles", back_populates="roles"
+        "User", secondary=UserRole.__table__, back_populates="roles"
     )
 
 
@@ -85,5 +85,5 @@ class Sector(Base):
     name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
 
     users: Mapped[list[User]] = relationship(
-        "User", secondary="user_sectors", back_populates="sectors"
+        "User", secondary=UserSector.__table__, back_populates="sectors"
     )

--- a/services/user-service/tests/test_healthz.py
+++ b/services/user-service/tests/test_healthz.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import pytest
 
-def test_healthz(client):
-    res = client.get("/healthz")
+
+@pytest.mark.asyncio
+async def test_healthz(client):
+    res = await client.get("/healthz")
     assert res.status_code == 200
     assert res.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- enable async startup seeding with AsyncSession
- configure Alembic for asyncpg and users schema
- run user-service tests with AsyncClient and Postgres

## Testing
- `pre-commit run --files services/user-service/app/main.py services/user-service/alembic.ini services/user-service/alembic/env.py services/user-service/tests/conftest.py services/user-service/tests/test_healthz.py services/user-service/tests/test_users.py services/user-service/Dockerfile requirements.txt`
- `pytest services/user-service/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689cfa42027c83239b9a2a632e94011c