### PR TITLE
feat: enable postgres backend for task service

### DIFF
--- a/services/task-service/Dockerfile
+++ b/services/task-service/Dockerfile
@@ -4,8 +4,8 @@ FROM python:3.12-slim
 WORKDIR /app
 
 COPY requirements.txt .
-RUN apt-get update && apt-get install -y curl sqlite3 && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir -r requirements.txt
+RUN apt-get update && apt-get install -y curl libpq-dev gcc && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r requirements.txt asyncpg
 
 COPY services/task-service /app
 

--- a/services/task-service/app/core/settings.py
+++ b/services/task-service/app/core/settings.py
@@ -9,7 +9,8 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     tasks_database_url: AnyUrl = Field(
-        "sqlite+aiosqlite:///./tasks.db", alias="TASKS_DATABASE_URL"
+        "postgresql+asyncpg://app:app@postgres/app?options=-csearch_path%3Dtasks",
+        alias="TASKS_DATABASE_URL",
     )
     auth_jwks_url: AnyHttpUrl = Field(
         "http://auth-service/jwks.json", alias="AUTH_JWKS_URL"

--- a/services/task-service/app/domain/models.py
+++ b/services/task-service/app/domain/models.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Optional
 
-from sqlalchemy import JSON, DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..core.database import Base
@@ -47,9 +48,9 @@ class Task(Base):
     due_date: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     code: Mapped[str] = mapped_column(String, nullable=False, unique=True)
-    assignee_ids: Mapped[list[int]] = mapped_column(JSON, default=list)
+    assignee_ids: Mapped[list[int]] = mapped_column(JSONB, default=list)
     sector_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
-    tags: Mapped[list[str]] = mapped_column(JSON, default=list)
+    tags: Mapped[list[str]] = mapped_column(JSONB, default=list)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
@@ -109,7 +110,7 @@ class ActivityLog(Base):
     )
     action: Mapped[str] = mapped_column(String, nullable=False)
     performed_by: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
-    details: Mapped[Optional[dict[str, Any]]] = mapped_column(JSON, nullable=True)
+    details: Mapped[Optional[dict[str, Any]]] = mapped_column(JSONB, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
     task: Mapped[Optional[Task]] = relationship("Task", back_populates="activity_logs")

--- a/services/task-service/tests/conftest.py
+++ b/services/task-service/tests/conftest.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import asyncpg
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+
+class DummyUserClient:
+    async def verify_users(self, user_ids):  # pragma: no cover - simple stub
+        return None
+
+    async def get_sector_name(self, sector_id):  # pragma: no cover - simple stub
+        return "Sector"
+
+
+@pytest_asyncio.fixture()
+async def session(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[AsyncSession]:
+    database_url = os.getenv(
+        "TEST_TASKS_DATABASE_URL",
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/test",
+    )
+    monkeypatch.setenv("TASKS_DATABASE_URL", database_url)
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from app.core.database import Base
+    sys.path.pop(0)
+
+    pool = await asyncpg.create_pool(database_url.replace("+asyncpg", ""))
+    async with pool.acquire() as conn:
+        await conn.execute("CREATE SCHEMA IF NOT EXISTS tasks")
+
+    engine = create_async_engine(database_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+
+    async_session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with async_session() as sess:
+            yield sess
+    finally:
+        await engine.dispose()
+        await pool.close()
+
+
+@pytest_asyncio.fixture()
+async def client(session: AsyncSession) -> AsyncIterator[tuple[AsyncClient, AsyncSession]]:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from app.api.tasks import get_task_service
+    from app.core.database import get_session
+    from app.main import app
+    from app.services.tasks import TaskService
+    sys.path.pop(0)
+
+    async def override_get_session() -> AsyncIterator[AsyncSession]:
+        yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[get_task_service] = lambda: TaskService(
+        user_client=DummyUserClient()
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac, session
+    app.dependency_overrides.clear()
+

--- a/services/task-service/tests/test_health_metrics.py
+++ b/services/task-service/tests/test_health_metrics.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
-import os
+import sys
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 
 # ruff: noqa: E402
-
-
-os.environ["TASKS_DATABASE_URL"] = "sqlite+aiosqlite://"
-
-import sys
-from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 

--- a/services/task-service/tests/test_task_service.py
+++ b/services/task-service/tests/test_task_service.py
@@ -5,30 +5,15 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
-import pytest_asyncio
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from app.core.database import Base
 from app.domain.models import Task
 from app.domain.schemas import ProjectCreate, Status, TaskCreate
 from app.repositories import ProjectRepository
 from app.services.tasks import TaskService
-
 sys.path.pop(0)
-from pydantic import ValidationError
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-
-
-@pytest_asyncio.fixture()
-async def session() -> AsyncSession:
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async with engine.begin() as conn:
-        await conn.exec_driver_sql("ATTACH DATABASE ':memory:' AS tasks")
-        await conn.run_sync(Base.metadata.create_all)
-    async_session = async_sessionmaker(engine, expire_on_commit=False)
-    async with async_session() as session:
-        yield session
-    await engine.dispose()
 
 
 class DummyUserClient:


### PR DESCRIPTION
## Summary
- default task service DB to Postgres
- run task service tests against Postgres with shared fixtures
- install Postgres client libs in task service image

## Testing
- `pytest services/task-service/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689cfd8cc00083239bcbefb3b0537c1f