### PR TITLE
docs: document search_path URLs and migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,10 @@
 # Environment variables example
 JWT_SECRET_KEY=change-me
 JWT_ALGORITHM=HS256
-DATABASE_URL=postgresql://app:app@localhost:5432/app
-TASKS_DATABASE_URL=sqlite+aiosqlite:///./tasks.db
+# URLs de banco compartilhando a mesma instância Postgres
+AUTH_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app?options=-csearch_path%3Dauth
+USER_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app?options=-csearch_path%3Dusers
+TASKS_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app?options=-csearch_path%3Dtasks
 SMTP_HOST=localhost
 SMTP_PORT=1025
 SMTP_USER=user


### PR DESCRIPTION
## Summary
- document per-service Postgres URLs using `search_path`
- add step-by-step guide to run migrations for each service in shared database

## Testing
- `pre-commit run --files .env.example README.md`
- `make test` *(fails: OSError: Multiple exceptions: [Errno 111] Connect call failed)*

------
https://chatgpt.com/codex/tasks/task_e_689d003e24f48323b8e0b332613267c0