### PR TITLE
fix: remove unsupported options from postgres URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,9 @@
 JWT_SECRET_KEY=change-me
 JWT_ALGORITHM=HS256
 # URLs de banco compartilhando a mesma instância Postgres
-AUTH_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app?options=-csearch_path%3Dauth
-USER_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app?options=-csearch_path%3Dusers
-TASKS_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app?options=-csearch_path%3Dtasks
+AUTH_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app
+USER_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app
+TASKS_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app
 SMTP_HOST=localhost
 SMTP_PORT=1025
 SMTP_USER=user

--- a/README.md
+++ b/README.md
@@ -29,13 +29,12 @@ cp .env.example .env
 ```
 
 O arquivo demonstra como cada serviço aponta para o mesmo banco Postgres
-utilizando schemas distintos via `search_path` e driver assíncrono
-`postgresql+asyncpg`:
+utilizando schemas distintos com o driver assíncrono `postgresql+asyncpg`:
 
 ```bash
-AUTH_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app?options=-csearch_path%3Dauth
-USER_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app?options=-csearch_path%3Dusers
-TASKS_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app?options=-csearch_path%3Dtasks
+AUTH_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app
+USER_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app
+TASKS_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app
 ```
 
 O arquivo **não deve** ser versionado. Em pipelines de CI/CD, defina as mesmas
@@ -47,22 +46,22 @@ Docker secrets e configurações da plataforma escolhida.
 Para aplicar as migrações de cada serviço em um único banco Postgres:
 
 1. Garanta que o banco esteja acessível.
-2. Defina a URL do serviço com o `search_path` adequado.
+2. Defina a URL do serviço.
 3. Execute o Alembic do serviço correspondente.
 
 Exemplo:
 
 ```bash
 # Auth
-export DATABASE_URL="postgresql+asyncpg://app:app@localhost:5432/app?options=-csearch_path%3Dauth"
+export DATABASE_URL="postgresql+asyncpg://app:app@localhost:5432/app"
 alembic -c services/auth-service/alembic.ini upgrade head
 
 # Users
-export DATABASE_URL="postgresql+asyncpg://app:app@localhost:5432/app?options=-csearch_path%3Dusers"
+export DATABASE_URL="postgresql+asyncpg://app:app@localhost:5432/app"
 alembic -c services/user-service/alembic.ini upgrade head
 
 # Tasks
-export TASKS_DATABASE_URL="postgresql+asyncpg://app:app@localhost:5432/app?options=-csearch_path%3Dtasks"
+export TASKS_DATABASE_URL="postgresql+asyncpg://app:app@localhost:5432/app"
 alembic -c services/task-service/alembic.ini upgrade head
 ```
 

--- a/compose.yml
+++ b/compose.yml
@@ -47,7 +47,7 @@ services:
       context: .
       dockerfile: services/auth-service/Dockerfile
     environment:
-      DATABASE_URL: "postgresql+asyncpg://app:app@postgres/app?options=-csearch_path%3Dauth"
+      DATABASE_URL: "postgresql+asyncpg://app:app@postgres/app"
     networks:
       - internal
       - traefik
@@ -79,7 +79,7 @@ services:
       context: .
       dockerfile: services/user-service/Dockerfile
     environment:
-      DATABASE_URL: "postgresql+asyncpg://app:app@postgres/app?options=-csearch_path%3Dusers"
+      DATABASE_URL: "postgresql+asyncpg://app:app@postgres/app"
     networks:
       - internal
       - traefik
@@ -103,7 +103,7 @@ services:
       context: .
       dockerfile: services/task-service/Dockerfile
     environment:
-      TASKS_DATABASE_URL: "postgresql+asyncpg://app:app@postgres/app?options=-csearch_path%3Dtasks"
+      TASKS_DATABASE_URL: "postgresql+asyncpg://app:app@postgres/app"
     networks:
       - internal
       - traefik

--- a/services/task-service/app/core/settings.py
+++ b/services/task-service/app/core/settings.py
@@ -9,7 +9,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     tasks_database_url: AnyUrl = Field(
-        "postgresql+asyncpg://app:app@postgres/app?options=-csearch_path%3Dtasks",
+        "postgresql+asyncpg://app:app@postgres/app",
         alias="TASKS_DATABASE_URL",
     )
     auth_jwks_url: AnyHttpUrl = Field(


### PR DESCRIPTION
## Summary
- drop unsupported `options` query parameter from service Postgres URLs
- update example env vars and documentation accordingly
- adjust tasks service settings to use plain asyncpg URL

## Testing
- `pre-commit run --files compose.yml .env.example README.md services/task-service/app/core/settings.py`
- `pytest` *(fails: OSError: Multiple exceptions: [Errno 111] Connect call failed)*

------
https://chatgpt.com/codex/tasks/task_e_689dbd0a71008323b6665734d69409d0