### PR TITLE
Handle asyncpg options parameter

### DIFF
--- a/services/user-service/app/database.py
+++ b/services/user-service/app/database.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from sqlalchemy import MetaData, create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -20,6 +21,25 @@ class Base(DeclarativeBase):
 settings = get_settings()
 
 database_url = str(settings.database_url)
+connect_args: dict[str, dict[str, str]] = {}
+
+if "options=" in database_url:
+    split_url = urlsplit(database_url)
+    query_params = dict(parse_qsl(split_url.query))
+    options = query_params.pop("options", None)
+    if options and options.startswith("-csearch_path="):
+        search_path = options.split("=", 1)[1]
+        connect_args["server_settings"] = {"search_path": search_path}
+    database_url = urlunsplit(
+        (
+            split_url.scheme,
+            split_url.netloc,
+            split_url.path,
+            urlencode(query_params),
+            split_url.fragment,
+        )
+    )
+
 if database_url.startswith("sqlite://") and not database_url.startswith(
     "sqlite+aiosqlite://"
 ):
@@ -27,7 +47,7 @@ if database_url.startswith("sqlite://") and not database_url.startswith(
 if database_url.startswith("sqlite+aiosqlite://"):
     metadata.schema = None
 
-async_engine = create_async_engine(database_url)
+async_engine = create_async_engine(database_url, connect_args=connect_args)
 async_session_factory = async_sessionmaker(
     async_engine, expire_on_commit=False, class_=AsyncSession
 )

--- a/services/user-service/tests/test_database.py
+++ b/services/user-service/tests/test_database.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_database_url_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    db_url = (
+        "postgresql+asyncpg://app:app@localhost:5432/app"
+        "?options=-csearch_path%3Dusers"
+    )
+    monkeypatch.setenv("DATABASE_URL", db_url)
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    for key in list(sys.modules):
+        if key.startswith("app"):
+            sys.modules.pop(key, None)
+
+    captured: dict[str, object] = {}
+
+    def fake_create_async_engine(url: str, **kwargs):  # type: ignore[no-untyped-def]
+        captured["url"] = url
+        captured["connect_args"] = kwargs.get("connect_args")
+
+        class Dummy:  # pragma: no cover - simple stub
+            pass
+
+        return Dummy()
+
+    def fake_create_engine(url: str, **kwargs):  # type: ignore[no-untyped-def]
+        class Dummy:  # pragma: no cover - simple stub
+            pass
+
+        return Dummy()
+
+    monkeypatch.setattr(
+        "sqlalchemy.ext.asyncio.create_async_engine", fake_create_async_engine
+    )
+    monkeypatch.setattr("sqlalchemy.create_engine", fake_create_engine)
+
+    import app.database as database
+
+    importlib.reload(database)
+
+    assert captured["url"] == "postgresql+asyncpg://app:app@localhost:5432/app"
+    assert captured["connect_args"] == {"server_settings": {"search_path": "users"}}


### PR DESCRIPTION
## Summary
- sanitize DATABASE_URL to translate `options` into asyncpg `server_settings`
- add test ensuring search_path options are handled

## Testing
- `pre-commit run --files services/user-service/app/database.py services/user-service/tests/test_database.py`
- `pytest services/user-service/tests/test_database.py`
- `pytest services/user-service/tests/test_database.py services/user-service/tests/test_healthz.py services/user-service/tests/test_users.py` *(fails: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0))*

------
https://chatgpt.com/codex/tasks/task_e_689dbd265bf8832392afdc63e45f2cc8