### PR TITLE
Implement sector lookup endpoint and tests

### DIFF
--- a/services/task-service/tests/test_user_client.py
+++ b/services/task-service/tests/test_user_client.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from app.services.user_client import UserServiceClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_get_sector_name_success(monkeypatch):
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"id": 1, "name": "Sector"})
+
+    transport = httpx.MockTransport(handler)
+    original_async_client = httpx.AsyncClient
+
+    def client_factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return original_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", client_factory)
+
+    client = UserServiceClient(base_url="http://test")
+    name1 = await client.get_sector_name(1)
+    name2 = await client.get_sector_name(1)
+    assert name1 == "Sector"
+    assert name2 == "Sector"
+    assert calls == 1
+
+
+async def test_get_sector_name_not_found(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    original_async_client = httpx.AsyncClient
+
+    def client_factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return original_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", client_factory)
+
+    client = UserServiceClient(base_url="http://test")
+    with pytest.raises(HTTPException):
+        await client.get_sector_name(1)

--- a/services/user-service/app/api.py
+++ b/services/user-service/app/api.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import selectinload
 
 from . import models, schemas, security
 from .database import get_db
-from .repositories import ProjectMemberRepository
+from .repositories import ProjectMemberRepository, SectorRepository
 
 router = APIRouter()
 
@@ -151,6 +151,21 @@ async def list_sectors(
 ):
     result = await db.execute(select(models.Sector))
     return result.scalars().all()
+
+
+sector_repo = SectorRepository()
+
+
+@router.get("/sectors/{sector_id}", response_model=schemas.SectorRead)
+async def get_sector(
+    sector_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    payload: dict = Depends(security.get_current_payload),
+):
+    sector = await sector_repo.get(db, sector_id)
+    if not sector:
+        raise HTTPException(status_code=404, detail="Sector not found")
+    return sector
 
 
 project_member_repo = ProjectMemberRepository()

--- a/services/user-service/app/repositories/__init__.py
+++ b/services/user-service/app/repositories/__init__.py
@@ -1,3 +1,4 @@
 from .project_members import ProjectMemberRepository
+from .sectors import SectorRepository
 
-__all__ = ["ProjectMemberRepository"]
+__all__ = ["ProjectMemberRepository", "SectorRepository"]

--- a/services/user-service/app/repositories/sectors.py
+++ b/services/user-service/app/repositories/sectors.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import models
+
+
+class SectorRepository:
+    """Data access layer for sectors."""
+
+    async def get(
+        self, session: AsyncSession, sector_id: UUID
+    ) -> models.Sector | None:
+        return await session.get(models.Sector, sector_id)

--- a/services/user-service/tests/test_sectors.py
+++ b/services/user-service/tests/test_sectors.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from .conftest import create_token
+
+pytestmark = pytest.mark.asyncio
+
+
+async def get_admin_token() -> str:
+    from app import models
+    from app.database import async_session_factory
+
+    async with async_session_factory() as db:
+        admin = (
+            (await db.execute(select(models.User).filter_by(email="admin@example.com")))
+            .scalars()
+            .first()
+        )
+        assert admin is not None
+        return create_token(str(admin.id), ["admin"])
+
+
+async def test_get_sector(client):
+    token = await get_admin_token()
+    res_list = await client.get("/sectors", headers={"Authorization": f"Bearer {token}"})
+    assert res_list.status_code == 200
+    sectors = res_list.json()
+    assert sectors
+    sector_id = sectors[0]["id"]
+    res = await client.get(
+        f"/sectors/{sector_id}", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["id"] == sector_id
+    assert data["name"] == sectors[0]["name"]
+
+
+async def test_get_sector_not_found(client):
+    token = await get_admin_token()
+    res = await client.get(
+        f"/sectors/{uuid.uuid4()}", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert res.status_code == 404


### PR DESCRIPTION
## Summary
- add repository and endpoint to fetch a sector by id
- test sector retrieval and user client sector caching

## Testing
- `pytest` (fails: ImportError and connection errors)

------
https://chatgpt.com/codex/tasks/task_e_689dcaf8b820832395943ad874294d60