### PR TITLE
fix: unify CORS_ALLOW_ORIGINS env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,4 +9,5 @@ SMTP_HOST=localhost
 SMTP_PORT=1025
 SMTP_USER=user
 SMTP_PASSWORD=password
+# Lista de origens permitidas para CORS (separadas por vírgula)
 CORS_ALLOW_ORIGINS=http://localhost

--- a/README.md
+++ b/README.md
@@ -35,11 +35,14 @@ utilizando schemas distintos com o driver assíncrono `postgresql+asyncpg`:
 AUTH_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app
 USER_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app
 TASKS_DATABASE_URL=postgresql+asyncpg://app:app@localhost:5432/app
+CORS_ALLOW_ORIGINS=http://localhost
 ```
 
 O arquivo **não deve** ser versionado. Em pipelines de CI/CD, defina as mesmas
 variáveis diretamente no ambiente de execução ou utilize mecanismos seguros como
 Docker secrets e configurações da plataforma escolhida.
+
+`CORS_ALLOW_ORIGINS` aceita uma lista separada por vírgulas com as origens permitidas pelo middleware CORS.
 
 ## Migrações de banco
 

--- a/services/task-service/app/core/settings.py
+++ b/services/task-service/app/core/settings.py
@@ -18,7 +18,7 @@ class Settings(BaseSettings):
     user_service_base_url: AnyHttpUrl = Field(
         "http://user-service", alias="USER_SERVICE_BASE_URL"
     )
-    cors_allowed_origins: List[str] = Field(["*"], alias="CORS_ALLOWED_ORIGINS")
+    cors_allow_origins: List[str] = Field(["*"], alias="CORS_ALLOW_ORIGINS")
     log_level: str = Field("INFO", alias="LOG_LEVEL")
     pagination_default: int = Field(50, alias="PAGINATION_DEFAULT")
     pagination_max: int = Field(100, alias="PAGINATION_MAX")
@@ -32,7 +32,7 @@ class Settings(BaseSettings):
         extra="forbid",
     )
 
-    @field_validator("cors_allowed_origins", mode="before")
+    @field_validator("cors_allow_origins", mode="before")
     @classmethod
     def split_origins(cls, v: str | list[str]) -> list[str]:
         if isinstance(v, str):

--- a/services/task-service/app/main.py
+++ b/services/task-service/app/main.py
@@ -5,6 +5,7 @@ from .api.health import router as health_router
 from .api.router import router
 from .core.logging import configure_logging
 from .core.middleware import MetricsMiddleware, RequestIDMiddleware
+from .core.settings import settings
 
 configure_logging()
 
@@ -14,10 +15,7 @@ app.add_middleware(RequestIDMiddleware)
 app.add_middleware(MetricsMiddleware)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "https://app.tasks.localhost",
-        "http://app.tasks.localhost",
-    ],
+    allow_origins=settings.cors_allow_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- align task-service with CORS_ALLOW_ORIGINS env var
- expose configurable CORS origins in task-service
- document CORS_ALLOW_ORIGINS usage

## Testing
- `pre-commit run --files .env.example README.md services/task-service/app/core/settings.py services/task-service/app/main.py`
- `make typecheck` *(fails: There are no .py[i] files in directory '.')*
- `make test` *(fails: OSError: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_689ddd2c7bf08323bf9ba120c9a30385