### PR TITLE
feat(web): support internal API URL

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -126,6 +126,8 @@ services:
     build:
       context: .
       dockerfile: web/Dockerfile
+    environment:
+      INTERNAL_API_URL: http://auth-service:8000
     networks:
       - internal
       - traefik

--- a/web/app/.env.local
+++ b/web/app/.env.local
@@ -1,1 +1,2 @@
-NEXT_PUBLIC_API_BASE=https://api.tasks.localhost
+NEXT_PUBLIC_API_URL=http://api.tasks.localhost
+INTERNAL_API_URL=http://auth-service:8000

--- a/web/app/src/lib/api.ts
+++ b/web/app/src/lib/api.ts
@@ -1,7 +1,12 @@
 import axios from 'axios';
 
+const baseURL =
+  typeof window === 'undefined'
+    ? process.env.INTERNAL_API_URL
+    : process.env.NEXT_PUBLIC_API_URL;
+
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://api.tasks.localhost',
+  baseURL: baseURL || 'http://api.tasks.localhost',
   withCredentials: true,
 });
 


### PR DESCRIPTION
## Summary
- add INTERNAL_API_URL for web service
- use INTERNAL_API_URL server-side in web api client

## Testing
- `pre-commit run --files compose.yml web/app/.env.local web/app/src/lib/api.ts`
- `npm test`
- `npm run lint`
- `docker compose build web` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de17ab2148323a0e2dc467da12f08