### PR TITLE
fix: restrict traefik ports to localhost

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -6,8 +6,8 @@ services:
       - --providers.docker.exposedbydefault=false
       - --providers.file.filename=/etc/traefik/dynamic.yml
     ports:
-      - "80:80"
-      - "8080:8080"
+      - "127.0.0.1:80:80"
+      - "127.0.0.1:8080:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./docker/traefik/traefik.yml:/etc/traefik/traefik.yml:ro


### PR DESCRIPTION
## Summary
- limit Traefik's exposed ports to localhost to avoid stray external connections
- revert Traefik forwarding timeouts to defaults

## Testing
- `pre-commit run --files compose.yml docker/traefik/dynamic.yml`
- `make typecheck` *(fails: There are no .py[i] files in directory '.')*
- `make test` *(fails: ImportError: cannot import name 'security' ...; Multiple exceptions: [Errno 111] Connect call failed ...)*

------
https://chatgpt.com/codex/tasks/task_e_689de4600ca88323b60a5bcfbcacf0ed