### PR TITLE
fix: seed admin credentials and enable CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ docker compose up
 As aplicações web e APIs estarão acessíveis em `app.tasks.localhost` e
 `api.tasks.localhost`.
 
+O `user-service` cria automaticamente um usuário administrador com e-mail
+`admin@example.com`. Um registro correspondente é gerado no `auth-service`
+com a senha inicial `admin`.
+
 ## Desenvolvimento local no macOS
 
 Para executar a aplicação web localmente em um ambiente macOS:

--- a/services/auth-service/app/seed.py
+++ b/services/auth-service/app/seed.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from . import models, security
+
+
+async def seed_initial_data(db: AsyncSession) -> None:
+    admin = (
+        (await db.execute(select(models.AuthUser).filter_by(email="admin@example.com")))
+        .scalars()
+        .first()
+    )
+    if not admin:
+        admin = models.AuthUser(
+            email="admin@example.com",
+            password_hash=security.hash_password("admin"),
+        )
+        db.add(admin)
+        await db.commit()


### PR DESCRIPTION
## Summary
- seed admin user with a default password in auth-service
- enable CORS headers for auth-service
- document initial admin credentials

## Testing
- `pre-commit run --files README.md services/auth-service/app/main.py services/auth-service/app/seed.py`
- `mypy .` *(fails: There are no .py[i] files in directory '.')*
- `pytest --cov --cov-report=term-missing` *(fails: OSError: Multiple exceptions: [Errno 111] Connect call failed...)*

------
https://chatgpt.com/codex/tasks/task_e_689dfbe025408323838c0fd3ffbaac65