### PR TITLE
feat: allow CORS headers and methods in Traefik config

### DIFF
--- a/docker/traefik/dynamic.yml
+++ b/docker/traefik/dynamic.yml
@@ -28,6 +28,16 @@ http:
           - "http://app.tasks.localhost"
           - "https://app.tasks.localhost"
         accessControlAllowCredentials: true
+        accessControlAllowHeaders:
+          - "Content-Type"
+          - "Authorization"
+        accessControlAllowMethods:
+          - "GET"
+          - "POST"
+          - "PUT"
+          - "PATCH"
+          - "DELETE"
+          - "OPTIONS"
         addVaryHeader: true
     compress:
       compress: {}


### PR DESCRIPTION
## Summary
- allow Content-Type and Authorization headers in Traefik CORS middleware
- enable typical HTTP methods in Traefik CORS middleware

## Testing
- `pre-commit run --files docker/traefik/dynamic.yml`
- `pytest` *(fails: Multiple exceptions: [Errno 111] Connect call failed)*
- `docker compose restart traefik` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_689e02e25c68832388d4b6169c5ed56a