### PR TITLE
fix: traefik log errors by removing unused HTTPS entrypoint

### DIFF
--- a/docker/traefik/dynamic.yml
+++ b/docker/traefik/dynamic.yml
@@ -1,9 +1,5 @@
 http:
   middlewares:
-    https-redirect:
-      redirectScheme:
-        scheme: https
-        permanent: true
     secure-headers:
       headers:
         frameDeny: true

--- a/docker/traefik/traefik.yml
+++ b/docker/traefik/traefik.yml
@@ -4,8 +4,6 @@ api:
 entryPoints:
   web:
     address: ":80"
-  websecure:
-    address: ":443"
 
 providers:
   docker:


### PR DESCRIPTION
## Summary
- remove unused `websecure` entrypoint from Traefik static config
- drop unused HTTPS redirect middleware

## Testing
- `pre-commit run --files docker/traefik/traefik.yml docker/traefik/dynamic.yml`
- `mypy .`
- `pytest --cov --cov-report=term-missing` *(fails: ImportError and connection errors)*


------
https://chatgpt.com/codex/tasks/task_e_689e0f586c7c83239c0cf050dd3b6d61